### PR TITLE
Add sharon and kalvin as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Owners below will be automatically requested for review on new pull requests
+# For details see: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+kalvinwang
+sharonwarner


### PR DESCRIPTION
Adding us as codeowners means we don’t have to click and type the other person’s name on new PRs, it'll automatically request a review!