### PR TITLE
Enable live reloading for faster development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ public/**/*.css
 public/**/*.js
 public/**/*.map
 
+# .hot files are generated for hot reloading
+public/.hot/*
+
 # Manifest files are generated during the compile process
 src/**/manifest-*.json
 

--- a/nodemon.config.json
+++ b/nodemon.config.json
@@ -3,9 +3,6 @@
 	"ignore": [
 		"public/",
 		"node_modules/",
-		"webpack.common.config.js",
-		"webpack.dev.config.js",
-		"webpack.prod.config.js",
 		"src/client/",
 		"src/data/manifest-scripts.json",
 		"src/data/manifest-styles.json"

--- a/nodemon.config.json
+++ b/nodemon.config.json
@@ -7,6 +7,7 @@
 		"webpack.dev.config.js",
 		"webpack.prod.config.js",
 		"src/client/",
-		"src/data/manifest-scripts.json"
+		"src/data/manifest-scripts.json",
+		"src/data/manifest-styles.json"
 	]
 }

--- a/nodemon.config.json
+++ b/nodemon.config.json
@@ -1,0 +1,13 @@
+{
+	"verbose": true,
+	"ignore": [
+		"public/",
+		"node_modules/",
+		"webpack.common.config.js",
+		"webpack.dev.config.js",
+		"webpack.prod.config.js",
+		"src/client/",
+		"src/data/manifest-scripts.json",
+		"src/data/manifest-styles.json"
+	]
+}

--- a/nodemon.config.json
+++ b/nodemon.config.json
@@ -7,7 +7,6 @@
 		"webpack.dev.config.js",
 		"webpack.prod.config.js",
 		"src/client/",
-		"src/data/manifest-scripts.json",
-		"src/data/manifest-styles.json"
+		"src/data/manifest-scripts.json"
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7986,6 +7986,12 @@
         "@babel/runtime": "^7.5.5"
       }
     },
+    "i18next-hmr": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/i18next-hmr/-/i18next-hmr-1.4.1.tgz",
+      "integrity": "sha512-0x1Rg6YrnkLK3DuZ0S9bz7VF+Wuvmz2xhEo5HNjT1LxZLCPgvMVOCXsl7muvYzYYjgzyzBjSsHgJAIPHd9WBlQ==",
+      "dev": true
+    },
     "i18next-http-backend": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2264,6 +2264,12 @@
         }
       }
     },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
@@ -2280,6 +2286,12 @@
           "dev": true
         }
       }
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "dev": true
     },
     "ansi-regex": {
       "version": "4.1.0",
@@ -7767,6 +7779,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
+      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -16443,6 +16461,75 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+      "dev": true,
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+          "dev": true
+        }
+      }
+    },
+    "webpack-hot-middleware": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.0.tgz",
+      "integrity": "sha512-xs5dPOrGPCzuRXNi8F6rwhawWvQQkeli5Ro48PRuQh8pYPCPmNnltP9itiUPT4xI8oW+y0m59lyyeQk54s5VgA==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "html-entities": "^1.2.0",
+        "querystring": "^0.2.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "eslint-plugin-react-hooks": "^2.3.0",
         "husky": "^3.1.0",
         "i18next": "^19.0.3",
+        "i18next-hmr": "^1.4.1",
         "jest": "^24.9.0",
         "jest-junit": "^9.0.0",
         "lint-staged": "^9.4.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "prebuild": "npm run clean-build-dir",
         "build:css": "postcss src/client/**/[!_]*.scss -d public/build/css --ext css",
         "build:css:dev": "npm run build:css -- --env development",
-        "build:js": "NODE_ENV=production webpack",
+        "build:js": "NODE_ENV=production webpack --config webpack.prod.config.js",
         "clean-build-dir": "rm -fr public/build/",
         "lint:css": "stylelint --allow-empty-input",
         "lint:css:all": "npm run lint:css -- ./**/*.scss",
@@ -23,7 +23,7 @@
         "test:watch": "jest --watch",
         "watch:css": "chokidar \"src/client/**/*.scss\" -c \"npm run build:css:dev\"",
         "prewatch:css": "npm run build:css:dev",
-        "watch:js": "webpack"
+        "watch:js": "webpack --config webpack.dev.config.js"
     },
     "dependencies": {
         "axios": "^0.19.2",
@@ -97,6 +97,9 @@
         "webpack": "^4.41.2",
         "webpack-bundle-analyzer": "^3.6.0",
         "webpack-cli": "^3.3.10",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-hot-middleware": "^2.25.0",
+        "webpack-merge": "4.2.2",
         "webpackbar": "^4.0.0"
     },
     "husky": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,3 +1,3 @@
 {
-  "helloWorld": "¡Hola mundo!"
+  "helloWorld": "¡Holas mundo!"
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,3 +1,3 @@
 {
-  "helloWorld": "¡Holas mundo!"
+  "helloWorld": "¡Hola mundo!"
 }

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,10 @@ const express = require("express");
 const helmet = require("helmet");
 const routes = require("./routes");
 
+const webpack = require("webpack");
+const webpackConfig = require("../webpack.dev.config.js");
+const webpackCompiler = webpack(webpackConfig);
+
 /**
  * @returns {object} Express application
  */
@@ -23,6 +27,18 @@ function init() {
    * Set various HTTP headers to reduce security vulnerabilities
    */
   app.use(helmet());
+
+  app.use(
+    require("webpack-dev-middleware")(webpackCompiler, {
+      noInfo: true,
+      publicPath: webpackConfig.output.publicPath,
+    })
+  );
+  app.use(
+    require("webpack-hot-middleware")(webpackCompiler, {
+      path: "/__webpack_hmr",
+    })
+  );
 
   /**
    * Serve static assets from the public/ directory. This middleware should

--- a/src/app.js
+++ b/src/app.js
@@ -6,10 +6,6 @@ const express = require("express");
 const helmet = require("helmet");
 const routes = require("./routes");
 
-const webpack = require("webpack");
-const webpackConfig = require("../webpack.dev.config.js");
-const webpackCompiler = webpack(webpackConfig);
-
 /**
  * @returns {object} Express application
  */
@@ -30,6 +26,10 @@ function init() {
 
   // On dev, enable hot reloading
   if (process.env.NODE_ENV === "development") {
+    const webpack = require("webpack");
+    const webpackConfig = require("../webpack.dev.config.js");
+    const webpackCompiler = webpack(webpackConfig);
+
     app.use(
       require("webpack-dev-middleware")(webpackCompiler, {
         noInfo: true,

--- a/src/app.js
+++ b/src/app.js
@@ -28,17 +28,20 @@ function init() {
    */
   app.use(helmet());
 
-  app.use(
-    require("webpack-dev-middleware")(webpackCompiler, {
-      noInfo: true,
-      publicPath: webpackConfig.output.publicPath,
-    })
-  );
-  app.use(
-    require("webpack-hot-middleware")(webpackCompiler, {
-      path: "/__webpack_hmr",
-    })
-  );
+  // On dev, enable hot reloading
+  if (process.env.NODE_ENV === "development") {
+    app.use(
+      require("webpack-dev-middleware")(webpackCompiler, {
+        noInfo: true,
+        publicPath: webpackConfig.output.publicPath,
+      })
+    );
+    app.use(
+      require("webpack-hot-middleware")(webpackCompiler, {
+        path: "/__webpack_hmr",
+      })
+    );
+  }
 
   /**
    * Serve static assets from the public/ directory. This middleware should

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -8,7 +8,7 @@ function Page() {
   return (
     <div>
       {t("helloWorld")}
-      <Badge>New</Badge>
+      <Badge>News</Badge>
     </div>
   );
 }

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -7,8 +7,11 @@ function Page() {
 
   return (
     <div>
-      {t("helloWorld")}
-      <Badge>News</Badge>
+      <Header />
+      <main>
+        {t("helloWorld")} <Badge>New</Badge> <br />
+      </main>
+      <Footer />
     </div>
   );
 }

--- a/src/client/i18n.js
+++ b/src/client/i18n.js
@@ -24,7 +24,7 @@ i18n
     load: "languageOnly", // ignore the -US in en-US
   });
 
-if (process.env.NODE_ENV !== "production") {
+if (process.env.NODE_ENV === "development") {
   const { applyClientHMR } = require("i18next-hmr");
   applyClientHMR(i18n);
 }

--- a/src/client/i18n.js
+++ b/src/client/i18n.js
@@ -24,4 +24,9 @@ i18n
     load: "languageOnly", // ignore the -US in en-US
   });
 
+if (process.env.NODE_ENV !== "production") {
+  const { applyClientHMR } = require("i18next-hmr");
+  applyClientHMR(i18n);
+}
+
 export default i18n;

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -11,10 +11,6 @@ const WebpackBar = require("webpackbar");
 const path = require("path");
 const webpack = require("webpack");
 
-// Identify what environment we're bundling for
-const env = process.env.NODE_ENV || "development";
-const IS_DEV = env === "development";
-
 // Setup our paths
 const resolveApp = (relativePath) => path.resolve(__dirname, relativePath);
 const paths = {
@@ -28,13 +24,6 @@ const paths = {
  * Base configuration
  */
 const config = {
-  devtool: IS_DEV ? "cheap-module-source-map" : "source-map",
-  entry: {
-    // Note: the name of this is important, since it's used when manifest-scripts.json
-    // is generated, which is a dependency on the server-side
-    client: ["./src/client/index.js"],
-  },
-  mode: env,
   module: {
     rules: [
       // Transform ES6 with Babel
@@ -67,51 +56,6 @@ const config = {
     aliasFields: ["browser"],
   },
 };
-
-/**
- * Development configuration additions
- */
-if (IS_DEV) {
-  console.log(
-    "👀 Webpack will run in watch mode and compile client-side JS files when they change"
-  );
-  config.stats = "errors-warnings";
-  config.watch = true;
-  config.watchOptions = {
-    ignored: /node_modules/,
-  };
-}
-
-/**
- * Production configuration additions
- */
-if (!IS_DEV) {
-  console.log("📦 Webpack optimizations");
-
-  config.optimization = {
-    // Minify the output
-    minimizer: [
-      new TerserPlugin({
-        // Use multi-process parallel running to improve the build speed
-        // Default number of concurrent runs: os.cpus().length - 1
-        parallel: true,
-        // Enable file caching
-        cache: true,
-        // Retain source map
-        sourceMap: true,
-      }),
-    ],
-  };
-
-  config.plugins = [
-    ...config.plugins,
-    // Define process.env.NODE_ENV for optimized React bundles
-    new webpack.DefinePlugin({
-      "process.env.NODE_ENV": JSON.stringify(env),
-    }),
-    new webpack.optimize.AggressiveMergingPlugin(),
-  ];
-}
 
 // Visualize the bundle and its dependencies
 // Set `WEBPACK_ANALYZE_BUNDLE` on the command line to enable

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -16,12 +16,12 @@ const env = process.env.NODE_ENV || "development";
 const IS_DEV = env === "development";
 
 // Setup our paths
-const resolveApp = relativePath => path.resolve(__dirname, relativePath);
+const resolveApp = (relativePath) => path.resolve(__dirname, relativePath);
 const paths = {
   appData: resolveApp("src/data/"),
   appPublic: resolveApp("public"),
   appSrc: resolveApp("src"),
-  sharedModule: resolveApp("shared-module")
+  sharedModule: resolveApp("shared-module"),
 };
 
 /**
@@ -32,7 +32,7 @@ const config = {
   entry: {
     // Note: the name of this is important, since it's used when manifest-scripts.json
     // is generated, which is a dependency on the server-side
-    client: ["./src/client/index.js"]
+    client: ["./src/client/index.js"],
   },
   mode: env,
   module: {
@@ -42,30 +42,30 @@ const config = {
       {
         test: /\.js$/,
         include: [paths.appSrc, paths.sharedModule],
-        loader: require.resolve("babel-loader")
-      }
-    ]
+        loader: require.resolve("babel-loader"),
+      },
+    ],
   },
   output: {
-    filename: "build/js/client.[chunkhash:8].js",
-    chunkFilename: "build/js/[name].[chunkhash:8].js",
+    filename: "build/js/client.js",
+    chunkFilename: "build/js/[name].js",
     path: paths.appPublic,
-    publicPath: "/"
+    publicPath: "/",
   },
   plugins: [
     // Output our JS file paths in a manifest file
     new AssetsPlugin({
       path: paths.appData,
-      filename: "manifest-scripts.json"
+      filename: "manifest-scripts.json",
     }),
     // Show a visual progress bar in the CLI
     new WebpackBar({
-      name: "Client-side JS bundle"
-    })
+      name: "Client-side JS bundle",
+    }),
   ],
   resolve: {
-    aliasFields: ["browser"]
-  }
+    aliasFields: ["browser"],
+  },
 };
 
 /**
@@ -78,7 +78,7 @@ if (IS_DEV) {
   config.stats = "errors-warnings";
   config.watch = true;
   config.watchOptions = {
-    ignored: /node_modules/
+    ignored: /node_modules/,
   };
 }
 
@@ -98,18 +98,18 @@ if (!IS_DEV) {
         // Enable file caching
         cache: true,
         // Retain source map
-        sourceMap: true
-      })
-    ]
+        sourceMap: true,
+      }),
+    ],
   };
 
   config.plugins = [
     ...config.plugins,
     // Define process.env.NODE_ENV for optimized React bundles
     new webpack.DefinePlugin({
-      "process.env.NODE_ENV": JSON.stringify(env)
+      "process.env.NODE_ENV": JSON.stringify(env),
     }),
-    new webpack.optimize.AggressiveMergingPlugin()
+    new webpack.optimize.AggressiveMergingPlugin(),
   ];
 }
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -4,6 +4,8 @@ const path = require("path");
 const webpack = require("webpack");
 const { I18NextHMRPlugin } = require("i18next-hmr/plugin");
 
+// 👀 Webpack will run in watch mode and compile client-side JS files when they change
+
 module.exports = merge(common, {
   mode: "development",
   entry: {
@@ -12,12 +14,10 @@ module.exports = merge(common, {
       "webpack-hot-middleware/client?path=/__webpack_hmr&reload=true",
     ],
   },
+  devtool: "eval-cheap-module-source-map", // https://webpack.js.org/configuration/devtool/
   output: {
     hotUpdateChunkFilename: ".hot/hot-update.js",
     hotUpdateMainFilename: ".hot/hot-update.json",
-  },
-  watchOptions: {
-    ignored: "/node_modules/",
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
@@ -25,4 +25,9 @@ module.exports = merge(common, {
       localesDir: path.resolve(__dirname, "public/locales"),
     }),
   ],
+  stats: "errors-warnings",
+  watch: true,
+  watchOptions: {
+    ignored: "/node_modules",
+  },
 });

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -12,9 +12,6 @@ module.exports = merge(common, {
     ],
   },
   output: {
-    // publicPath: '/static/js/',
-    // path: filePath,
-    // filename: fileName
     hotUpdateChunkFilename: ".hot/hot-update.js",
     hotUpdateMainFilename: ".hot/hot-update.json",
   },

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,25 @@
+const merge = require("webpack-merge");
+const common = require("./webpack.common.config.js");
+const path = require("path");
+const webpack = require("webpack");
+
+module.exports = merge(common, {
+  mode: "development",
+  entry: {
+    client: [
+      path.join(__dirname, "src/client/index.js"),
+      "webpack-hot-middleware/client?path=/__webpack_hmr&reload=true",
+    ],
+  },
+  output: {
+    // publicPath: '/static/js/',
+    // path: filePath,
+    // filename: fileName
+    hotUpdateChunkFilename: ".hot/hot-update.js",
+    hotUpdateMainFilename: ".hot/hot-update.json",
+  },
+  watchOptions: {
+    ignored: "/node_modules/",
+  },
+  plugins: [new webpack.HotModuleReplacementPlugin()],
+});

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -2,6 +2,7 @@ const merge = require("webpack-merge");
 const common = require("./webpack.common.config.js");
 const path = require("path");
 const webpack = require("webpack");
+const { I18NextHMRPlugin } = require("i18next-hmr/plugin");
 
 module.exports = merge(common, {
   mode: "development",
@@ -18,5 +19,10 @@ module.exports = merge(common, {
   watchOptions: {
     ignored: "/node_modules/",
   },
-  plugins: [new webpack.HotModuleReplacementPlugin()],
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new I18NextHMRPlugin({
+      localesDir: path.resolve(__dirname, "public/locales"),
+    }),
+  ],
 });

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -3,4 +3,32 @@ const common = require("./webpack.common.config.js");
 
 module.exports = merge(common, {
   mode: "production",
+  entry: {
+    // Note: the name of this is important, since it's used when manifest-scripts.json
+    // is generated, which is a dependency on the server-side
+    client: ["./src/client/index.js"],
+  },
+  devtool: "source-map", // https://webpack.js.org/configuration/devtool/
+  optimization: {
+    // Minify the output
+    minimizer: [
+      new TerserPlugin({
+        // Use multi-process parallel running to improve the build speed
+        // Default number of concurrent runs: os.cpus().length - 1
+        parallel: true,
+        // Enable file caching
+        cache: true,
+        // Retain source map
+        sourceMap: true,
+      }),
+    ],
+  },
+  plugins: [
+    ...config.plugins,
+    // Define process.env.NODE_ENV for optimized React bundles
+    new webpack.DefinePlugin({
+      "process.env.NODE_ENV": JSON.stringify(env),
+    }),
+    new webpack.optimize.AggressiveMergingPlugin(),
+  ],
 });

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,0 +1,6 @@
+const merge = require("webpack-merge");
+const common = require("./webpack.common.config.js");
+
+module.exports = merge(common, {
+  mode: "production",
+});


### PR DESCRIPTION
This PR enables live reloading with the help of https://github.com/webpack-contrib/webpack-hot-middleware and https://github.com/felixmosh/i18next-hmr

Which means developers no longer have to manually refresh to view every change; instead, saving changes to a file will cause the connected browser window to refresh automatically.

If you're using any modern browser, you don't have to do anything special to connect the the browser, just open localhost:3000 per usual.

It has some rough edges in how it interacts with Nodemon. E.g. modifying webpack config files or anything else that causes Nodemon to trigger a Webpack rebuild, will cause an error in the connected browser window, which then needs to be manually refreshed. I've captured them in this future polish ticket: https://github.com/cagov/benefits-screener/issues/47

I had to dig into Webpack's config to complete this task so along the way I refactored webpack.config.js into separate dev, prod, and common config files, which seems to be a best practice / recommended by Webpack's docs.