### PR TITLE
Add titles, next buttons, and tabbed pane content containers

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -9,5 +9,6 @@
   "tab3Title": "How to apply",
   "tab4Title": "After you submit your application",
   "tab5Title": "Getting your benefits",
-  "tab6Title": "More Resources"
+  "tab6Title": "More Resources",
+  "buttonNextPrefix": "Next: "
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -5,5 +5,6 @@
   "tab3Title": "How to apply",
   "tab4Title": "After you submit your application",
   "tab5Title": "Getting your benefits",
-  "tab6Title": "More Resources"
+  "tab6Title": "More Resources",
+  "buttonNextPrefix": "Next: "
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,4 +1,8 @@
 {
+  "subheaderButton": "Apply for your UI benefits on UI Online",
+  "subheaderHeader": "Applying to Unemployment Insurance",
+  "subheaderSubheader": "Start here to learn how to apply and receive unemployment benefits.",
+  "subheaderParagraph": "Unemployment insurance (UI) pays part of your income after your employer lays you off or reduces your hours. Due to COVID-19, new programs are available to help you get through this time. New programs include Pandemic Unemployment Assistance (PUA), Pandemic Emergency Unemployment Compensation (P-EUC), and the Federal Pandemic Unemployment Compensation (FPUC).",
   "tab0Title": "Unemployment and COVID-19",
   "tab1Title": "Who should apply",
   "tab2Title": "What you need before you apply",

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -4,7 +4,7 @@ import React from "react";
 function TabPaneContent0() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
 export default TabPaneContent0;

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -4,7 +4,7 @@ import React from "react";
 function TabPaneContent0() {
   // const { t } = useTranslation();
 
-  return <div>blah</div>;
+  return <div>I think this tab was deleted from the mockup?</div>;
 }
 
 export default TabPaneContent0;

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent1/index.js
+++ b/src/client/components/TabPaneContent1/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent1/index.js
+++ b/src/client/components/TabPaneContent1/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0() {
+function TabPaneContent1() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
-export default TabPaneContent0;
+export default TabPaneContent1;

--- a/src/client/components/TabPaneContent2/index.js
+++ b/src/client/components/TabPaneContent2/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0() {
+function TabPaneContent2() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
-export default TabPaneContent0;
+export default TabPaneContent2;

--- a/src/client/components/TabPaneContent2/index.js
+++ b/src/client/components/TabPaneContent2/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent3/index.js
+++ b/src/client/components/TabPaneContent3/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0() {
+function TabPaneContent3() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
-export default TabPaneContent0;
+export default TabPaneContent3;

--- a/src/client/components/TabPaneContent3/index.js
+++ b/src/client/components/TabPaneContent3/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent4/index.js
+++ b/src/client/components/TabPaneContent4/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0() {
+function TabPaneContent4() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
-export default TabPaneContent0;
+export default TabPaneContent4;

--- a/src/client/components/TabPaneContent4/index.js
+++ b/src/client/components/TabPaneContent4/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent5/index.js
+++ b/src/client/components/TabPaneContent5/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0() {
+function TabPaneContent5() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
-export default TabPaneContent0;
+export default TabPaneContent5;

--- a/src/client/components/TabPaneContent5/index.js
+++ b/src/client/components/TabPaneContent5/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent6/index.js
+++ b/src/client/components/TabPaneContent6/index.js
@@ -1,0 +1,10 @@
+import React from "react";
+// import { useTranslation } from "react-i18next";
+
+function TabPaneContent0() {
+  // const { t } = useTranslation();
+
+  return <div />;
+}
+
+export default TabPaneContent0;

--- a/src/client/components/TabPaneContent6/index.js
+++ b/src/client/components/TabPaneContent6/index.js
@@ -1,10 +1,10 @@
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0() {
+function TabPaneContent6() {
   // const { t } = useTranslation();
 
-  return <div />;
+  return <div>blah</div>;
 }
 
-export default TabPaneContent0;
+export default TabPaneContent6;

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
   fluid={false}
 >
   <TabContainer
+    activeKey={0}
     defaultActiveKey="0"
     id="left-tabs-example"
   >
@@ -35,6 +36,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={0}
+              href="#tab0Title"
+              onClick={[Function]}
             >
               tab0Title
             </NavLink>
@@ -52,6 +55,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={1}
+              href="#tab1Title"
+              onClick={[Function]}
             >
               tab1Title
             </NavLink>
@@ -69,6 +74,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={2}
+              href="#tab2Title"
+              onClick={[Function]}
             >
               tab2Title
             </NavLink>
@@ -86,6 +93,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={3}
+              href="#tab3Title"
+              onClick={[Function]}
             >
               tab3Title
             </NavLink>
@@ -103,6 +112,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={4}
+              href="#tab4Title"
+              onClick={[Function]}
             >
               tab4Title
             </NavLink>
@@ -120,6 +131,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={5}
+              href="#tab5Title"
+              onClick={[Function]}
             >
               tab5Title
             </NavLink>
@@ -137,6 +150,8 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={6}
+              href="#tab6Title"
+              onClick={[Function]}
             >
               tab6Title
             </NavLink>
@@ -151,43 +166,124 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             eventKey={0}
             key="0"
           >
-            tab0Content
+            <h2>
+              tab0Title
+            </h2>
+            <TabPaneContent0 />
+            <Button
+              active={false}
+              disabled={false}
+              href="#tab1Title"
+              onClick={[Function]}
+              type="button"
+              variant="secondary"
+            >
+              buttonNextPrefixtab1Title
+            </Button>
           </TabPane>
           <TabPane
             eventKey={1}
             key="1"
           >
-            tab1Content
+            <h2>
+              tab1Title
+            </h2>
+            <TabPaneContent1 />
+            <Button
+              active={false}
+              disabled={false}
+              href="#tab2Title"
+              onClick={[Function]}
+              type="button"
+              variant="secondary"
+            >
+              buttonNextPrefixtab2Title
+            </Button>
           </TabPane>
           <TabPane
             eventKey={2}
             key="2"
           >
-            tab2Content
+            <h2>
+              tab2Title
+            </h2>
+            <TabPaneContent2 />
+            <Button
+              active={false}
+              disabled={false}
+              href="#tab3Title"
+              onClick={[Function]}
+              type="button"
+              variant="secondary"
+            >
+              buttonNextPrefixtab3Title
+            </Button>
           </TabPane>
           <TabPane
             eventKey={3}
             key="3"
           >
-            tab3Content
+            <h2>
+              tab3Title
+            </h2>
+            <TabPaneContent3 />
+            <Button
+              active={false}
+              disabled={false}
+              href="#tab4Title"
+              onClick={[Function]}
+              type="button"
+              variant="secondary"
+            >
+              buttonNextPrefixtab4Title
+            </Button>
           </TabPane>
           <TabPane
             eventKey={4}
             key="4"
           >
-            tab4Content
+            <h2>
+              tab4Title
+            </h2>
+            <TabPaneContent4 />
+            <Button
+              active={false}
+              disabled={false}
+              href="#tab5Title"
+              onClick={[Function]}
+              type="button"
+              variant="secondary"
+            >
+              buttonNextPrefixtab5Title
+            </Button>
           </TabPane>
           <TabPane
             eventKey={5}
             key="5"
           >
-            tab5Content
+            <h2>
+              tab5Title
+            </h2>
+            <TabPaneContent5 />
+            <Button
+              active={false}
+              disabled={false}
+              href="#tab6Title"
+              onClick={[Function]}
+              type="button"
+              variant="secondary"
+            >
+              buttonNextPrefixtab6Title
+            </Button>
           </TabPane>
           <TabPane
             eventKey={6}
             key="6"
           >
-            tab6Content
+            <h2>
+              tab6Title
+            </h2>
+            <TabPaneContent6 />
           </TabPane>
         </ForwardRef>
       </Col>

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -7,7 +7,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
   <TabContainer
     activeKey={0}
     defaultActiveKey="0"
-    id="left-tabs-example"
+    id="left-tabs"
   >
     <Row
       className="tabbed-container"

--- a/src/client/components/TabbedContainer/_index.scss
+++ b/src/client/components/TabbedContainer/_index.scss
@@ -1,5 +1,5 @@
 .tabbed-container {
-  padding: 2rem 0rem;
+  padding: 2rem 0;
 
   .nav-item {
     border: 1px solid rgba(0, 0, 0, 0.125);
@@ -18,6 +18,6 @@
   }
 
   .tab-pane > div {
-    padding: 1rem 0rem;
+    padding: 1rem 0;
   }
 }

--- a/src/client/components/TabbedContainer/_index.scss
+++ b/src/client/components/TabbedContainer/_index.scss
@@ -16,4 +16,8 @@
   .nav-pills .nav-link {
     border-radius: 0;
   }
+
+  .tab-pane > div {
+    padding: 1rem 0rem;
+  }
 }

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -1,7 +1,8 @@
+import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
-import React from "react";
+import React, { useState } from "react";
 import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
 import { useTranslation } from "react-i18next";
@@ -30,16 +31,32 @@ function TabbedContainer() {
     "tab6Content",
   ];
 
+  const [activeKey, setActiveKey] = useState(0);
+
+  const handleClick = (key) => {
+    setActiveKey(key);
+  };
+
   return (
     <Container>
-      <Tab.Container id="left-tabs-example" defaultActiveKey="0">
+      <Tab.Container
+        id="left-tabs-example"
+        defaultActiveKey="0"
+        activeKey={activeKey}
+      >
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
             <Nav variant="pills" className="flex-column">
               {tabTitleKeys.map((value, index) => {
                 return (
                   <Nav.Item key={index}>
-                    <Nav.Link eventKey={index}>{t(value)}</Nav.Link>
+                    <Nav.Link
+                      eventKey={index}
+                      href={"#" + value}
+                      onClick={handleClick.bind(this, index)}
+                    >
+                      {t(value)}
+                    </Nav.Link>
                   </Nav.Item>
                 );
               })}
@@ -47,10 +64,17 @@ function TabbedContainer() {
           </Col>
           <Col sm={8}>
             <Tab.Content>
-              {tabContentKeys.map((value, index) => {
+              {tabTitleKeys.map((value, index) => {
                 return (
                   <Tab.Pane eventKey={index} key={index}>
-                    {t(value)}
+                    <h2>{t(value)}</h2>
+                    <Button
+                      variant="secondary"
+                      href={"#" + tabTitleKeys[index + 1]}
+                      onClick={handleClick.bind(this, index + 1)}
+                    >
+                      {t("buttonNextPrefix") + t(tabTitleKeys[index + 1])}
+                    </Button>
                   </Tab.Pane>
                 );
               })}

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -5,6 +5,14 @@ import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
 import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
+// We generate these tab names dynamically and assign them to TabePaneContentTagName
+import TabPaneContent0 from "../TabPaneContent0"; // eslint-disable-line no-unused-vars
+import TabPaneContent1 from "../TabPaneContent1"; // eslint-disable-line no-unused-vars
+import TabPaneContent2 from "../TabPaneContent2"; // eslint-disable-line no-unused-vars
+import TabPaneContent3 from "../TabPaneContent3"; // eslint-disable-line no-unused-vars
+import TabPaneContent4 from "../TabPaneContent4"; // eslint-disable-line no-unused-vars
+import TabPaneContent5 from "../TabPaneContent5"; // eslint-disable-line no-unused-vars
+import TabPaneContent6 from "../TabPaneContent6"; // eslint-disable-line no-unused-vars
 import { useTranslation } from "react-i18next";
 
 function TabbedContainer() {
@@ -31,7 +39,6 @@ function TabbedContainer() {
         <Button
           variant="secondary"
           href={"#" + tabTitleKeys[index + 1]}
-          // TODO(kalvin): fix this very slight performance issue
           onClick={() => setActiveKey(activeKey + 1)}
         >
           {t("buttonNextPrefix") + t(tabTitleKeys[index + 1])}
@@ -68,9 +75,11 @@ function TabbedContainer() {
           <Col sm={8}>
             <Tab.Content>
               {tabTitleKeys.map((value, index) => {
+                const TabePaneContentTagName = "TabPaneContent" + index;
                 return (
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{t(value)}</h2>
+                    <TabePaneContentTagName />
                     {renderNextButton(index)}
                   </Tab.Pane>
                 );

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -30,6 +30,8 @@ function TabbedContainer() {
     "tab6Title",
   ];
 
+  // This mapping is needed because React doesn't allow strings as component names
+  // TODO(kalvin): find a less hacky way of getting content into these tab panes
   const tabPaneContent = {
     0: TabPaneContent0,
     1: TabPaneContent1,

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -5,7 +5,7 @@ import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
 import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
-// We generate these tab names dynamically and assign them to TabePaneContentTagName
+// We generate these tab names dynamically and assign them to TabPaneContentTagName
 import TabPaneContent0 from "../TabPaneContent0"; // eslint-disable-line no-unused-vars
 import TabPaneContent1 from "../TabPaneContent1"; // eslint-disable-line no-unused-vars
 import TabPaneContent2 from "../TabPaneContent2"; // eslint-disable-line no-unused-vars
@@ -59,11 +59,7 @@ function TabbedContainer() {
 
   return (
     <Container>
-      <Tab.Container
-        id="left-tabs-example"
-        defaultActiveKey="0"
-        activeKey={activeKey}
-      >
+      <Tab.Container id="left-tabs" defaultActiveKey="0" activeKey={activeKey}>
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
             <Nav variant="pills" className="flex-column">
@@ -85,11 +81,11 @@ function TabbedContainer() {
           <Col sm={8}>
             <Tab.Content>
               {tabTitleKeys.map((value, index) => {
-                const TabePaneContentTagName = tabPaneContent[index];
+                const TabPaneContentTagName = tabPaneContent[index];
                 return (
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{t(value)}</h2>
-                    <TabePaneContentTagName />
+                    <TabPaneContentTagName />
                     {renderNextButton(index)}
                   </Tab.Pane>
                 );

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -5,14 +5,13 @@ import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
 import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
-// We generate these tab names dynamically and assign them to TabPaneContentTagName
-import TabPaneContent0 from "../TabPaneContent0"; // eslint-disable-line no-unused-vars
-import TabPaneContent1 from "../TabPaneContent1"; // eslint-disable-line no-unused-vars
-import TabPaneContent2 from "../TabPaneContent2"; // eslint-disable-line no-unused-vars
-import TabPaneContent3 from "../TabPaneContent3"; // eslint-disable-line no-unused-vars
-import TabPaneContent4 from "../TabPaneContent4"; // eslint-disable-line no-unused-vars
-import TabPaneContent5 from "../TabPaneContent5"; // eslint-disable-line no-unused-vars
-import TabPaneContent6 from "../TabPaneContent6"; // eslint-disable-line no-unused-vars
+import TabPaneContent0 from "../TabPaneContent0";
+import TabPaneContent1 from "../TabPaneContent1";
+import TabPaneContent2 from "../TabPaneContent2";
+import TabPaneContent3 from "../TabPaneContent3";
+import TabPaneContent4 from "../TabPaneContent4";
+import TabPaneContent5 from "../TabPaneContent5";
+import TabPaneContent6 from "../TabPaneContent6";
 import { useTranslation } from "react-i18next";
 
 function TabbedContainer() {

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -30,6 +30,16 @@ function TabbedContainer() {
     "tab6Title",
   ];
 
+  const tabPaneContent = {
+    0: TabPaneContent0,
+    1: TabPaneContent1,
+    2: TabPaneContent2,
+    3: TabPaneContent3,
+    4: TabPaneContent4,
+    5: TabPaneContent5,
+    6: TabPaneContent6,
+  };
+
   const [activeKey, setActiveKey] = useState(0);
 
   const renderNextButton = (index) => {
@@ -75,7 +85,7 @@ function TabbedContainer() {
           <Col sm={8}>
             <Tab.Content>
               {tabTitleKeys.map((value, index) => {
-                const TabePaneContentTagName = "TabPaneContent" + index;
+                const TabePaneContentTagName = tabPaneContent[index];
                 return (
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{t(value)}</h2>

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -2,6 +2,7 @@ import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
+// TODO(kalvin): fix this ordering error
 import React, { useState } from "react";
 import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
@@ -37,6 +38,22 @@ function TabbedContainer() {
     setActiveKey(key);
   };
 
+  const renderNextButton = (index) => {
+    // Don't display the next button on the final tab
+    if (index < tabTitleKeys.length - 1) {
+      return (
+        <Button
+          variant="secondary"
+          href={"#" + tabTitleKeys[index + 1]}
+          // TODO(kalvin): fix this very slight performance issue
+          onClick={handleClick.bind(this, index + 1)}
+        >
+          {t("buttonNextPrefix") + t(tabTitleKeys[index + 1])}
+        </Button>
+      );
+    }
+  };
+
   return (
     <Container>
       <Tab.Container
@@ -53,6 +70,7 @@ function TabbedContainer() {
                     <Nav.Link
                       eventKey={index}
                       href={"#" + value}
+                      // TODO(kalvin): fix this very slight performance issue
                       onClick={handleClick.bind(this, index)}
                     >
                       {t(value)}
@@ -68,13 +86,7 @@ function TabbedContainer() {
                 return (
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{t(value)}</h2>
-                    <Button
-                      variant="secondary"
-                      href={"#" + tabTitleKeys[index + 1]}
-                      onClick={handleClick.bind(this, index + 1)}
-                    >
-                      {t("buttonNextPrefix") + t(tabTitleKeys[index + 1])}
-                    </Button>
+                    {renderNextButton(index)}
                   </Tab.Pane>
                 );
               })}

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -1,9 +1,8 @@
+import React, { useState } from "react";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
-// TODO(kalvin): fix this ordering error
-import React, { useState } from "react";
 import Row from "react-bootstrap/Row";
 import Tab from "react-bootstrap/Tab";
 import { useTranslation } from "react-i18next";
@@ -22,21 +21,8 @@ function TabbedContainer() {
     "tab5Title",
     "tab6Title",
   ];
-  const tabContentKeys = [
-    "tab0Content",
-    "tab1Content",
-    "tab2Content",
-    "tab3Content",
-    "tab4Content",
-    "tab5Content",
-    "tab6Content",
-  ];
 
   const [activeKey, setActiveKey] = useState(0);
-
-  const handleClick = (key) => {
-    setActiveKey(key);
-  };
 
   const renderNextButton = (index) => {
     // Don't display the next button on the final tab
@@ -46,7 +32,7 @@ function TabbedContainer() {
           variant="secondary"
           href={"#" + tabTitleKeys[index + 1]}
           // TODO(kalvin): fix this very slight performance issue
-          onClick={handleClick.bind(this, index + 1)}
+          onClick={() => setActiveKey(activeKey + 1)}
         >
           {t("buttonNextPrefix") + t(tabTitleKeys[index + 1])}
         </Button>
@@ -70,8 +56,7 @@ function TabbedContainer() {
                     <Nav.Link
                       eventKey={index}
                       href={"#" + value}
-                      // TODO(kalvin): fix this very slight performance issue
-                      onClick={handleClick.bind(this, index)}
+                      onClick={() => setActiveKey(index)}
                     >
                       {t(value)}
                     </Nav.Link>


### PR DESCRIPTION
This PR adds stub files for each tabbed pane's content, and automatically generated titles / next buttons in each pane.  

Need to update that tab pane animation so it stops fading in and out so slowly...

![preview edd guide](https://user-images.githubusercontent.com/82277/80166341-b1604680-85ab-11ea-8a1b-81802da0305c.gif)
