### PR TITLE
Anchor the app to /guide

### DIFF
--- a/src/data/routes.js
+++ b/src/data/routes.js
@@ -6,7 +6,7 @@
  */
 const routes = {
   home: {
-    path: "/"
+    path: "/guide"
     // We exclude the Home `component` so we can manually import it into pages/index.js
   }
 };

--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -13,12 +13,15 @@ const singlePageAppRouter = Router();
 singlePageAppRouter.get("/*", (req, res) => {
   const cssURL = getCdnPath(`/build/css/${manifestStyles["App.css"]}`);
 
-  const is404 = !Object.values(pageRoutes)
+  const shouldRedirect = !Object.values(pageRoutes)
     .map((r) => r.path)
     .includes(req.path);
-  const statusCode = is404 ? 404 : 200;
+  if (shouldRedirect) {
+      res.status(301).location(pageRoutes.home.path).send();
+      return;
+  }
 
-  res.status(statusCode).send(
+  res.status(200).send(
     `<!doctype html>
     <html lang="en">
     <head>

--- a/src/routes/single-page-app.test.js
+++ b/src/routes/single-page-app.test.js
@@ -1,19 +1,27 @@
-import { init } from "../app";
 import request from "supertest";
+import { init } from "../app";
 
 const server = init();
 
 describe("Router: Single page app", () => {
   it("renders homepage", async () => {
-    const res = await request(server).get("/");
+    const res = await request(server).get("/guide");
 
     expect(res.status).toBe(200);
     expect(res.text).toMatch(/<html/);
   });
 
-  it("returns 404 status code", async () => {
-    const res = await request(server).get("/derp");
+  it("returns 301 status code", async () => {
+    const res = await request(server).get("/guide/");
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(301);
+    expect(res.get('Location')).toBe('/guide');
+  });
+
+  it("returns 301 status code", async () => {
+    const res = await request(server).get("/");
+
+    expect(res.status).toBe(301);
+    expect(res.get('Location')).toBe('/guide');
   });
 });

--- a/src/routes/single-page-app.test.js
+++ b/src/routes/single-page-app.test.js
@@ -1,5 +1,5 @@
-import request from "supertest";
 import { init } from "../app";
+import request from "supertest";
 
 const server = init();
 

--- a/src/routes/single-page-app.test.js
+++ b/src/routes/single-page-app.test.js
@@ -4,21 +4,21 @@ import { init } from "../app";
 const server = init();
 
 describe("Router: Single page app", () => {
-  it("renders homepage", async () => {
+  it("renders to /guide", async () => {
     const res = await request(server).get("/guide");
 
     expect(res.status).toBe(200);
     expect(res.text).toMatch(/<html/);
   });
 
-  it("returns 301 status code", async () => {
+  it("/guide/ returns 301 status code", async () => {
     const res = await request(server).get("/guide/");
 
     expect(res.status).toBe(301);
     expect(res.get('Location')).toBe('/guide');
   });
 
-  it("returns 301 status code", async () => {
+  it("/ returns 301 status code", async () => {
     const res = await request(server).get("/");
 
     expect(res.status).toBe(301);


### PR DESCRIPTION
Attempts to access any other path will redirect to /guide.

This fixes images being broken when there is a trailing slash
in the url.