### PR TITLE
Scroll to sidebar top when clicking tabs, next buttons, and links

### DIFF
--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0({ setActiveTab }) {
+function TabPaneContent0({ loadTab }) {
   // const { t } = useTranslation();
 
   return (
@@ -42,7 +42,7 @@ function TabPaneContent0({ setActiveTab }) {
         <a
           href="#tab0Title"
           onClick={() => {
-            setActiveTab(1);
+            loadTab(1);
             return false;
           }}
         >
@@ -150,7 +150,7 @@ function TabPaneContent0({ setActiveTab }) {
 }
 
 TabPaneContent0.propTypes = {
-  setActiveTab: PropTypes.any, // prop-types can't validate React Hooks yet
+  loadTab: PropTypes.any, // prop-types can't validate React Hooks yet
 };
 
 export default TabPaneContent0;

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -43,7 +43,6 @@ function TabPaneContent0({ loadTab }) {
           href="#tab0Title"
           onClick={() => {
             loadTab(1);
-            return false;
           }}
         >
           Receive Your Benefits
@@ -150,7 +149,7 @@ function TabPaneContent0({ loadTab }) {
 }
 
 TabPaneContent0.propTypes = {
-  loadTab: PropTypes.any, // prop-types can't validate React Hooks yet
+  loadTab: PropTypes.func,
 };
 
 export default TabPaneContent0;

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -151,7 +151,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               tab0Title
             </h2>
             <TabPaneContent0
-              setActiveTab={[Function]}
+              loadTab={[Function]}
             />
             <Button
               active={false}
@@ -172,7 +172,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               tab1Title
             </h2>
             <TabPaneContent1
-              setActiveTab={[Function]}
+              loadTab={[Function]}
             />
             <Button
               active={false}
@@ -193,7 +193,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               tab2Title
             </h2>
             <TabPaneContent2
-              setActiveTab={[Function]}
+              loadTab={[Function]}
             />
             <Button
               active={false}
@@ -214,7 +214,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               tab3Title
             </h2>
             <TabPaneContent3
-              setActiveTab={[Function]}
+              loadTab={[Function]}
             />
             <Button
               active={false}
@@ -235,7 +235,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               tab4Title
             </h2>
             <TabPaneContent4
-              setActiveTab={[Function]}
+              loadTab={[Function]}
             />
             <Button
               active={false}
@@ -256,7 +256,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               tab5Title
             </h2>
             <TabPaneContent5
-              setActiveTab={[Function]}
+              loadTab={[Function]}
             />
           </TabPane>
         </ForwardRef>

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
@@ -38,25 +38,48 @@ function TabbedContainer() {
     5: TabPaneContent5,
   };
 
+  const tabbedContainer = useRef(null);
   const [activeTab, setActiveTab] = useState(0);
 
-  const renderNextButton = (index) => {
+  useEffect(() => {
+    const sidebarOffset = tabbedContainer.current.offsetTop;
+
+    try {
+      // new API - https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo
+      window.scroll({
+        top: sidebarOffset,
+        left: 0,
+        behavior: "smooth",
+      });
+    } catch (error) {
+      // fallback for older browsers
+      window.scrollTo(0, sidebarOffset);
+    }
+  }, [activeTab]);
+
+  function LoadTab(tabIndex) {
+    setActiveTab(tabIndex);
+
+    return null;
+  }
+
+  const renderNextButton = (tabIndex) => {
     // Don't display the next button on the final tab
-    if (index < tabTitleKeys.length - 1) {
+    if (tabIndex < tabTitleKeys.length - 1) {
       return (
         <Button
           variant="secondary"
-          href={"#" + tabTitleKeys[index + 1]}
-          onClick={() => setActiveTab(activeTab + 1)}
+          href={"#" + tabTitleKeys[tabIndex + 1]}
+          onClick={() => LoadTab(tabIndex + 1)}
         >
-          {t("buttonNextPrefix") + t(tabTitleKeys[index + 1])}
+          {t("buttonNextPrefix") + t(tabTitleKeys[tabIndex + 1])}
         </Button>
       );
     }
   };
 
   return (
-    <Container>
+    <Container ref={tabbedContainer}>
       <Tab.Container id="left-tabs" defaultActiveKey="0" activeKey={activeTab}>
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
@@ -67,7 +90,7 @@ function TabbedContainer() {
                     <Nav.Link
                       eventKey={index}
                       href={"#" + value}
-                      onClick={() => setActiveTab(index)}
+                      onClick={() => LoadTab(index)}
                     >
                       {t(value)}
                     </Nav.Link>
@@ -83,7 +106,7 @@ function TabbedContainer() {
                 return (
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{t(value)}</h2>
-                    <TabPaneContentTagName setActiveTab={setActiveTab} />
+                    <TabPaneContentTagName loadTab={LoadTab} />
                     {renderNextButton(index)}
                   </Tab.Pane>
                 );

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -45,7 +45,7 @@ function TabbedContainer() {
     const sidebarOffset = tabbedContainer.current.offsetTop;
 
     try {
-      // new API - https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo
+      // smooth smooth scrolling for newer browsers
       window.scroll({
         top: sidebarOffset,
         left: 0,
@@ -57,7 +57,7 @@ function TabbedContainer() {
     }
   }, [activeTab]);
 
-  function LoadTab(tabIndex) {
+  function loadTab(tabIndex) {
     setActiveTab(tabIndex);
 
     return null;
@@ -70,7 +70,7 @@ function TabbedContainer() {
         <Button
           variant="secondary"
           href={"#" + tabTitleKeys[tabIndex + 1]}
-          onClick={() => LoadTab(tabIndex + 1)}
+          onClick={() => loadTab(tabIndex + 1)}
         >
           {t("buttonNextPrefix") + t(tabTitleKeys[tabIndex + 1])}
         </Button>
@@ -90,7 +90,7 @@ function TabbedContainer() {
                     <Nav.Link
                       eventKey={index}
                       href={"#" + value}
-                      onClick={() => LoadTab(index)}
+                      onClick={() => loadTab(index)}
                     >
                       {t(value)}
                     </Nav.Link>
@@ -106,7 +106,7 @@ function TabbedContainer() {
                 return (
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{t(value)}</h2>
-                    <TabPaneContentTagName loadTab={LoadTab} />
+                    <TabPaneContentTagName loadTab={loadTab} />
                     {renderNextButton(index)}
                   </Tab.Pane>
                 );


### PR DESCRIPTION
This PR scrolls the website to the top of the sidebar when clicking tabs, next buttons, and links, after rendering the new component

Tested on an actual iPhone and Chrome device emulator. Inline link doesn't scroll to the correct position in emulator for iPhones, but it does on the actual phone...

![scrolling](https://user-images.githubusercontent.com/82277/80411750-b3235600-889a-11ea-84a2-cde3c4e6a6c9.gif)
