### PR TITLE
Fix receive your benefits link and add text slugs for links

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -4,11 +4,13 @@
   "subheaderSubheader": "Learn what type of benefits you qualify for and how to apply for them.",
   "subheaderParagraph": "If you lost your job or had your hours reduced, and meet eligibility requirements, you may be eligible to receive Unemployment Insurance (UI) benefits from California’s Employment Development Department (EDD).",
   "subheaderParagraph2": "First register or login at Benefit Programs Online, then apply for unemployment benefits on UI Online.",
-  "tab0Title": "Benefits you can apply for",
-  "tab1Title": "What you need before you apply",
-  "tab2Title": "How to apply",
-  "tab3Title": "After you submit your application",
-  "tab4Title": "Receive your benefits",
-  "tab5Title": "More Resources",
+  "tabTitles": {
+    "0": "Benefits you can apply for",
+    "1": "What you need before you apply",
+    "2": "How to apply",
+    "3": "After you submit your application",
+    "4": "Receive your benefits",
+    "5": "More Resources"
+  },
   "buttonNextPrefix": "Next: "
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -4,11 +4,13 @@
   "subheaderSubheader": "Learn what type of benefits you qualify for and how to apply for them.",
   "subheaderParagraph": "If you lost your job or had your hours reduced, and meet eligibility requirements, you may be eligible to receive Unemployment Insurance (UI) benefits from California’s Employment Development Department (EDD).",
   "subheaderParagraph2": "First register or login at Benefit Programs Online, then apply for unemployment benefits on UI Online.",
-  "tab0Title": "Benefits you can apply for",
-  "tab1Title": "What you need before you apply",
-  "tab2Title": "How to apply",
-  "tab3Title": "After you submit your application",
-  "tab4Title": "Receive your benefits",
-  "tab5Title": "More Resources",
+  "tabTitles": {
+    "0": "Benefits you can apply for",
+    "1": "What you need before you apply",
+    "2": "How to apply",
+    "3": "After you submit your application",
+    "4": "Receive your benefits",
+    "5": "More Resources"
+  },
   "buttonNextPrefix": "Next: "
 }

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -2,8 +2,21 @@ import PropTypes from "prop-types";
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0({ loadTab }) {
+function TabPaneContent0({ loadTab, tabSlugs, getTabTitle }) {
   // const { t } = useTranslation();
+
+  function ReceiveYourBenefitsLink() {
+    return (
+      <a
+        href={"#" + tabSlugs[4]}
+        onClick={() => {
+          loadTab(4);
+        }}
+      >
+        {getTabTitle(4)}
+      </a>
+    );
+  }
 
   return (
     <div>
@@ -38,16 +51,8 @@ function TabPaneContent0({ loadTab }) {
         <li>Or, your previous UI claim has expired.</li>
       </ul>
       <p>
-        If you're already receiving UI, review{" "}
-        <a
-          href="#tab0Title"
-          onClick={() => {
-            loadTab(1);
-          }}
-        >
-          Receive Your Benefits
-        </a>{" "}
-        to learn how your UI claim is affected by COVID-19.
+        If you're already receiving UI, review <ReceiveYourBenefitsLink /> to
+        learn how your UI claim is affected by COVID-19.
       </p>
       <p>
         <a href="https://www.edd.ca.gov/Benefit_Programs_Online.htm">
@@ -150,6 +155,8 @@ function TabPaneContent0({ loadTab }) {
 
 TabPaneContent0.propTypes = {
   loadTab: PropTypes.func,
+  tabSlugs: PropTypes.arrayOf(PropTypes.string),
+  getTabTitle: PropTypes.func,
 };
 
 export default TabPaneContent0;

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -36,10 +36,10 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={0}
-              href="#tab0Title"
+              href="#benefits"
               onClick={[Function]}
             >
-              tab0Title
+              tabTitles.0
             </NavLink>
           </NavItem>
           <NavItem
@@ -55,10 +55,10 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={1}
-              href="#tab1Title"
+              href="#before-you-apply"
               onClick={[Function]}
             >
-              tab1Title
+              tabTitles.1
             </NavLink>
           </NavItem>
           <NavItem
@@ -74,10 +74,10 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={2}
-              href="#tab2Title"
+              href="#how-to-apply"
               onClick={[Function]}
             >
-              tab2Title
+              tabTitles.2
             </NavLink>
           </NavItem>
           <NavItem
@@ -93,10 +93,10 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={3}
-              href="#tab3Title"
+              href="#after-you-submit"
               onClick={[Function]}
             >
-              tab3Title
+              tabTitles.3
             </NavLink>
           </NavItem>
           <NavItem
@@ -112,10 +112,10 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={4}
-              href="#tab4Title"
+              href="#receive-benefits"
               onClick={[Function]}
             >
-              tab4Title
+              tabTitles.4
             </NavLink>
           </NavItem>
           <NavItem
@@ -131,10 +131,10 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={5}
-              href="#tab5Title"
+              href="#more-resources"
               onClick={[Function]}
             >
-              tab5Title
+              tabTitles.5
             </NavLink>
           </NavItem>
         </Nav>
@@ -148,20 +148,31 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             key="0"
           >
             <h2>
-              tab0Title
+              tabTitles.0
             </h2>
             <TabPaneContent0
+              getTabTitle={[Function]}
               loadTab={[Function]}
+              tabSlugs={
+                Array [
+                  "benefits",
+                  "before-you-apply",
+                  "how-to-apply",
+                  "after-you-submit",
+                  "receive-benefits",
+                  "more-resources",
+                ]
+              }
             />
             <Button
               active={false}
               disabled={false}
-              href="#tab1Title"
+              href="#before-you-apply"
               onClick={[Function]}
               type="button"
               variant="secondary"
             >
-              buttonNextPrefixtab1Title
+              buttonNextPrefixtabTitles.1
             </Button>
           </TabPane>
           <TabPane
@@ -169,20 +180,31 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             key="1"
           >
             <h2>
-              tab1Title
+              tabTitles.1
             </h2>
             <TabPaneContent1
+              getTabTitle={[Function]}
               loadTab={[Function]}
+              tabSlugs={
+                Array [
+                  "benefits",
+                  "before-you-apply",
+                  "how-to-apply",
+                  "after-you-submit",
+                  "receive-benefits",
+                  "more-resources",
+                ]
+              }
             />
             <Button
               active={false}
               disabled={false}
-              href="#tab2Title"
+              href="#how-to-apply"
               onClick={[Function]}
               type="button"
               variant="secondary"
             >
-              buttonNextPrefixtab2Title
+              buttonNextPrefixtabTitles.2
             </Button>
           </TabPane>
           <TabPane
@@ -190,20 +212,31 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             key="2"
           >
             <h2>
-              tab2Title
+              tabTitles.2
             </h2>
             <TabPaneContent2
+              getTabTitle={[Function]}
               loadTab={[Function]}
+              tabSlugs={
+                Array [
+                  "benefits",
+                  "before-you-apply",
+                  "how-to-apply",
+                  "after-you-submit",
+                  "receive-benefits",
+                  "more-resources",
+                ]
+              }
             />
             <Button
               active={false}
               disabled={false}
-              href="#tab3Title"
+              href="#after-you-submit"
               onClick={[Function]}
               type="button"
               variant="secondary"
             >
-              buttonNextPrefixtab3Title
+              buttonNextPrefixtabTitles.3
             </Button>
           </TabPane>
           <TabPane
@@ -211,20 +244,31 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             key="3"
           >
             <h2>
-              tab3Title
+              tabTitles.3
             </h2>
             <TabPaneContent3
+              getTabTitle={[Function]}
               loadTab={[Function]}
+              tabSlugs={
+                Array [
+                  "benefits",
+                  "before-you-apply",
+                  "how-to-apply",
+                  "after-you-submit",
+                  "receive-benefits",
+                  "more-resources",
+                ]
+              }
             />
             <Button
               active={false}
               disabled={false}
-              href="#tab4Title"
+              href="#receive-benefits"
               onClick={[Function]}
               type="button"
               variant="secondary"
             >
-              buttonNextPrefixtab4Title
+              buttonNextPrefixtabTitles.4
             </Button>
           </TabPane>
           <TabPane
@@ -232,20 +276,31 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             key="4"
           >
             <h2>
-              tab4Title
+              tabTitles.4
             </h2>
             <TabPaneContent4
+              getTabTitle={[Function]}
               loadTab={[Function]}
+              tabSlugs={
+                Array [
+                  "benefits",
+                  "before-you-apply",
+                  "how-to-apply",
+                  "after-you-submit",
+                  "receive-benefits",
+                  "more-resources",
+                ]
+              }
             />
             <Button
               active={false}
               disabled={false}
-              href="#tab5Title"
+              href="#more-resources"
               onClick={[Function]}
               type="button"
               variant="secondary"
             >
-              buttonNextPrefixtab5Title
+              buttonNextPrefixtabTitles.5
             </Button>
           </TabPane>
           <TabPane
@@ -253,10 +308,21 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
             key="5"
           >
             <h2>
-              tab5Title
+              tabTitles.5
             </h2>
             <TabPaneContent5
+              getTabTitle={[Function]}
               loadTab={[Function]}
+              tabSlugs={
+                Array [
+                  "benefits",
+                  "before-you-apply",
+                  "how-to-apply",
+                  "after-you-submit",
+                  "receive-benefits",
+                  "more-resources",
+                ]
+              }
             />
           </TabPane>
         </ForwardRef>

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -16,27 +16,27 @@ import { useTranslation } from "react-i18next";
 function TabbedContainer() {
   const { t } = useTranslation();
 
-  // We write these out instead of generating them
-  // so we can find them easily when searching for keys in translation.json
-  const tabTitleKeys = [
-    "tab0Title",
-    "tab1Title",
-    "tab2Title",
-    "tab3Title",
-    "tab4Title",
-    "tab5Title",
+  // The number and order of items here need to correspond to
+  // tabTitles in translation.json
+  const tabSlugs = [
+    "benefits",
+    "before-you-apply",
+    "how-to-apply",
+    "after-you-submit",
+    "receive-benefits",
+    "more-resources",
   ];
 
   // This mapping is needed because React doesn't allow strings as component names
   // TODO(kalvin): find a less hacky way of getting content into these tab panes
-  const tabPaneContent = {
-    0: TabPaneContent0,
-    1: TabPaneContent1,
-    2: TabPaneContent2,
-    3: TabPaneContent3,
-    4: TabPaneContent4,
-    5: TabPaneContent5,
-  };
+  const tabPaneContent = [
+    TabPaneContent0,
+    TabPaneContent1,
+    TabPaneContent2,
+    TabPaneContent3,
+    TabPaneContent4,
+    TabPaneContent5,
+  ];
 
   const tabbedContainer = useRef(null);
   const [activeTab, setActiveTab] = useState(0);
@@ -63,16 +63,21 @@ function TabbedContainer() {
     return null;
   }
 
+  function getTabTitle(tabIndex) {
+    return t("tabTitles." + tabIndex);
+  }
+
   const renderNextButton = (tabIndex) => {
     // Don't display the next button on the final tab
-    if (tabIndex < tabTitleKeys.length - 1) {
+    if (tabIndex < tabSlugs.length - 1) {
+      const nextTabIndex = tabIndex + 1;
       return (
         <Button
           variant="secondary"
-          href={"#" + tabTitleKeys[tabIndex + 1]}
-          onClick={() => loadTab(tabIndex + 1)}
+          href={"#" + tabSlugs[nextTabIndex]}
+          onClick={() => loadTab(nextTabIndex)}
         >
-          {t("buttonNextPrefix") + t(tabTitleKeys[tabIndex + 1])}
+          {t("buttonNextPrefix") + getTabTitle(nextTabIndex)}
         </Button>
       );
     }
@@ -84,7 +89,7 @@ function TabbedContainer() {
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
             <Nav variant="pills" className="flex-column">
-              {tabTitleKeys.map((value, index) => {
+              {tabSlugs.map((value, index) => {
                 return (
                   <Nav.Item key={index}>
                     <Nav.Link
@@ -92,7 +97,7 @@ function TabbedContainer() {
                       href={"#" + value}
                       onClick={() => loadTab(index)}
                     >
-                      {t(value)}
+                      {getTabTitle(index)}
                     </Nav.Link>
                   </Nav.Item>
                 );
@@ -101,12 +106,16 @@ function TabbedContainer() {
           </Col>
           <Col sm={8}>
             <Tab.Content>
-              {tabTitleKeys.map((value, index) => {
+              {tabSlugs.map((value, index) => {
                 const TabPaneContentTagName = tabPaneContent[index];
                 return (
                   <Tab.Pane eventKey={index} key={index}>
-                    <h2>{t(value)}</h2>
-                    <TabPaneContentTagName loadTab={loadTab} />
+                    <h2>{getTabTitle(index)}</h2>
+                    <TabPaneContentTagName
+                      loadTab={loadTab}
+                      tabSlugs={tabSlugs}
+                      getTabTitle={getTabTitle}
+                    />
                     {renderNextButton(index)}
                   </Tab.Pane>
                 );

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -40,8 +40,16 @@ function TabbedContainer() {
 
   const tabbedContainer = useRef(null);
   const [activeTab, setActiveTab] = useState(0);
+  const initialPageLoad = useRef(true);
 
+  // Scroll to the top of the sidebar when activeTab changes
   useEffect(() => {
+    // Don't scroll down to the top of the sidebar on initial page load
+    if (initialPageLoad.current) {
+      initialPageLoad.current = false;
+      return;
+    }
+
     const sidebarOffset = tabbedContainer.current.offsetTop;
 
     try {


### PR DESCRIPTION
This PR changes the receive your benefits link to the correct tab and adds text slugs for the navbar, buttons, and other links, so that we can label them accordingly in analytics