### PR TITLE
Add Google Analytics events to navigation within our page and to BPO

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3,7 +3,6 @@
   "subheaderHeader": "Guide to applying for unemployment benefits in California",
   "subheaderSubheader": "Learn what type of benefits you qualify for and how to apply for them.",
   "subheaderParagraph": "If you lost your job or had your hours reduced, and meet eligibility requirements, you may be eligible to receive Unemployment Insurance (UI) benefits from California’s Employment Development Department (EDD).",
-  "subheaderParagraph2": "First register or login at Benefit Programs Online, then apply for unemployment benefits on UI Online.",
   "tabTitles": {
     "0": "Benefits you can apply for",
     "1": "What you need before you apply",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -3,7 +3,6 @@
   "subheaderHeader": "Guide to applying for unemployment benefits in California",
   "subheaderSubheader": "Learn what type of benefits you qualify for and how to apply for them.",
   "subheaderParagraph": "If you lost your job or had your hours reduced, and meet eligibility requirements, you may be eligible to receive Unemployment Insurance (UI) benefits from California’s Employment Development Department (EDD).",
-  "subheaderParagraph2": "First register or login at Benefit Programs Online, then apply for unemployment benefits on UI Online.",
   "tabTitles": {
     "0": "Benefits you can apply for",
     "1": "What you need before you apply",

--- a/src/client/components/BPOButton/index.js
+++ b/src/client/components/BPOButton/index.js
@@ -1,0 +1,18 @@
+import Button from "react-bootstrap/Button";
+import React from "react";
+import logEvent from "../../utils.js";
+
+function BPOButton() {
+  return (
+    <Button
+      variant="secondary"
+      href="https://www.edd.ca.gov/Benefit_Programs_Online.htm"
+      onClick={() => logEvent("register-or-login")}
+      target="_blank"
+    >
+      Register or login at Benefits Programs Online
+    </Button>
+  );
+}
+
+export default BPOButton;

--- a/src/client/components/Subheader/__snapshots__/index.test.js.snap
+++ b/src/client/components/Subheader/__snapshots__/index.test.js.snap
@@ -19,15 +19,7 @@ exports[`<Subheader /> renders vertical navigation bar 1`] = `
     <p>
       First register or login at Benefit Programs Online, then apply for unemployment benefits on UI Online℠.
     </p>
-    <Button
-      active={false}
-      disabled={false}
-      href="https://portal.edd.ca.gov/WebApp/Login"
-      type="button"
-      variant="secondary"
-    >
-      subheaderButton
-    </Button>
+    <BPOButton />
   </div>
 </div>
 `;

--- a/src/client/components/Subheader/index.js
+++ b/src/client/components/Subheader/index.js
@@ -1,4 +1,4 @@
-import Button from "react-bootstrap/Button";
+import BPOButton from "../BPOButton";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -15,12 +15,7 @@ function Subheader() {
           First register or login at Benefit Programs Online, then apply for
           unemployment benefits on UI Online&#x2120;.
         </p>
-        <Button
-          variant="secondary"
-          href="https://portal.edd.ca.gov/WebApp/Login"
-        >
-          {t("subheaderButton")}
-        </Button>
+        <BPOButton />
       </div>
     </div>
   );

--- a/src/client/components/TabPaneContent2/index.js
+++ b/src/client/components/TabPaneContent2/index.js
@@ -1,5 +1,4 @@
-import Button from "react-bootstrap/Button";
-
+import BPOButton from "../BPOButton";
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
@@ -21,12 +20,7 @@ function TabPaneContent2() {
         </a>
         .
       </p>
-      <Button
-        variant="secondary"
-        href="https://www.edd.ca.gov/Benefit_Programs_Online.htm"
-      >
-        Register or log in at Benefits Programs Online
-      </Button>
+      <BPOButton />
       <h4>2. Submit your application</h4>
       <h5>
         Filling out employment information for COVID-19 claims in UI Online

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -11,6 +11,7 @@ import TabPaneContent2 from "../TabPaneContent2";
 import TabPaneContent3 from "../TabPaneContent3";
 import TabPaneContent4 from "../TabPaneContent4";
 import TabPaneContent5 from "../TabPaneContent5";
+import logEvent from "../../utils.js";
 import { useTranslation } from "react-i18next";
 
 function TabbedContainer() {
@@ -43,6 +44,7 @@ function TabbedContainer() {
   const initialPageLoad = useRef(true);
 
   // Scroll to the top of the sidebar when activeTab changes
+  // and log tab change to Google Analytics
   useEffect(() => {
     // Don't scroll down to the top of the sidebar on initial page load
     if (initialPageLoad.current) {
@@ -67,12 +69,17 @@ function TabbedContainer() {
 
   function loadTab(tabIndex) {
     setActiveTab(tabIndex);
+    logEvent(getTabHashFragment(activeTab));
 
     return null;
   }
 
   function getTabTitle(tabIndex) {
     return t("tabTitles." + tabIndex);
+  }
+
+  function getTabHashFragment(tabIndex) {
+    return `#${tabSlugs[tabIndex]}`;
   }
 
   const renderNextButton = (tabIndex) => {
@@ -82,7 +89,7 @@ function TabbedContainer() {
       return (
         <Button
           variant="secondary"
-          href={"#" + tabSlugs[nextTabIndex]}
+          href={getTabHashFragment(nextTabIndex)}
           onClick={() => loadTab(nextTabIndex)}
         >
           {t("buttonNextPrefix") + getTabTitle(nextTabIndex)}
@@ -102,7 +109,7 @@ function TabbedContainer() {
                   <Nav.Item key={index}>
                     <Nav.Link
                       eventKey={index}
-                      href={"#" + value}
+                      href={getTabHashFragment(index)}
                       onClick={() => loadTab(index)}
                     >
                       {getTabTitle(index)}
@@ -120,9 +127,9 @@ function TabbedContainer() {
                   <Tab.Pane eventKey={index} key={index}>
                     <h2>{getTabTitle(index)}</h2>
                     <TabPaneContentTagName
+                      getTabTitle={getTabTitle}
                       loadTab={loadTab}
                       tabSlugs={tabSlugs}
-                      getTabTitle={getTabTitle}
                     />
                     {renderNextButton(index)}
                   </Tab.Pane>

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -1,0 +1,7 @@
+// log to Google Analytics
+export default function LogEvent(label) {
+  window.gtag("event", "Navigate", {
+    event_category: "Unemployment",
+    event_label: label,
+  });
+}


### PR DESCRIPTION
This PR adds Google Analytics events to navigation within our page (sidebar tabs, next buttons, and internal links) and to external links to BPO. Tested live and working.

Todo: disable GA locally and on staging (the number of public visits should be 1000x-10000x or more so not a big deal) 