### PR TITLE
Make sidebar sticky

### DIFF
--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
         sm={4}
       >
         <Nav
-          className="flex-column"
+          className="flex-column sidebar-sticky"
           fill={false}
           justify={false}
           variant="pills"

--- a/src/client/components/TabbedContainer/_index.scss
+++ b/src/client/components/TabbedContainer/_index.scss
@@ -36,4 +36,10 @@
     margin: 1rem 0;
     border-left: 0.3rem solid $secondary;
   }
+
+  .sidebar-sticky {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+  }
 }

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -96,7 +96,7 @@ function TabbedContainer() {
       <Tab.Container id="left-tabs" defaultActiveKey="0" activeKey={activeTab}>
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
-            <Nav variant="pills" className="flex-column">
+            <Nav variant="pills" className="flex-column sidebar-sticky">
               {tabSlugs.map((value, index) => {
                 return (
                   <Nav.Item key={index}>


### PR DESCRIPTION
This PR makes the sidebar stick to the viewport when the user scrolls down so that it's always available for navigation. Degrades gracefully on mobile, i.e. doesn't stick.

Todo: add padding at top of navbar

![sticky sidebar](https://user-images.githubusercontent.com/82277/80431698-2095ad80-88c0-11ea-9024-e8684e7aa3ca.gif)
