### PR TITLE
Remove whitespace overflow on right side of mobile viewport

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "subheaderButton": "Register or log in with Benefits Programs Online",
+  "subheaderButton": "Register or log in with Benefit Programs Online",
   "subheaderHeader": "Guide to applying for unemployment benefits in California",
   "subheaderSubheader": "Learn what type of benefits you qualify for and how to apply for them.",
   "subheaderParagraph": "If you lost your job or had your hours reduced, and meet eligibility requirements, you may be eligible to receive Unemployment Insurance (UI) benefits from California’s Employment Development Department (EDD).",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,5 +1,5 @@
 {
-  "subheaderButton": "Register or log in with Benefits Programs Online",
+  "subheaderButton": "Register or log in with Benefit Programs Online",
   "subheaderHeader": "Guide to applying for unemployment benefits in California",
   "subheaderSubheader": "Learn what type of benefits you qualify for and how to apply for them.",
   "subheaderParagraph": "If you lost your job or had your hours reduced, and meet eligibility requirements, you may be eligible to receive Unemployment Insurance (UI) benefits from California’s Employment Development Department (EDD).",

--- a/src/client/App.js
+++ b/src/client/App.js
@@ -6,7 +6,7 @@ import TabbedContainer from "./components/TabbedContainer";
 
 function Page() {
   return (
-    <div>
+    <div id="overflow-wrapper">
       <Header />
       <main id="back-to-top">
         <Subheader />

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -6,11 +6,11 @@ $secondary: #fdb81e !default; //yellowish gold
 
 $font-size-base: 1.2rem !default;
 
-$line-height-base:            1.7 !default;
-$line-height-sm:              1.45 !default;
-$line-height-lg:              2.2 !default;
+$line-height-base: 1.7 !default;
+$line-height-sm: 1.45 !default;
+$line-height-lg: 2.2 !default;
 
-$paragraph-margin-bottom:   1.2rem !default;
+$paragraph-margin-bottom: 1.2rem !default;
 
 @import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&display=swap");
 
@@ -24,6 +24,18 @@ $font-family-sans-serif: "Source Sans Pro", sans-serif !default;
 @import "components/Footer/index";
 @import "components/TabbedContainer/index";
 
-h1, h2, h3, h4, h5, h6 {
-  font-weight:bold;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	font-weight: bold;
+}
+
+// Eliminate whitespace overflow on right half of mobile viewport
+// None of the usual solutions are compatible with sticky elements
+// But this solution is: https://stackoverflow.com/a/59019025/6074728
+#overflow-wrapper {
+	touch-action: pan-y pinch-zoom;
 }

--- a/src/client/components/BPOButton/index.js
+++ b/src/client/components/BPOButton/index.js
@@ -10,7 +10,7 @@ function BPOButton() {
       onClick={() => logEvent("register-or-login")}
       target="_blank"
     >
-      Register or log in at Benefits Programs Online
+      Register or log in at Benefit Programs Online
     </Button>
   );
 }

--- a/src/routes/single-page-app.js
+++ b/src/routes/single-page-app.js
@@ -17,8 +17,8 @@ singlePageAppRouter.get("/*", (req, res) => {
     .map((r) => r.path)
     .includes(req.path);
   if (shouldRedirect) {
-      res.status(301).location(pageRoutes.home.path).send();
-      return;
+    res.status(301).location(pageRoutes.home.path).send();
+    return;
   }
 
   res.status(200).send(


### PR DESCRIPTION
This PR removes the whitespace overflow on right side of the mobile viewport. Upon initial load it looked normal, but you could scroll to the right or zoom out to view the white space.

It uses an odd solution because the usual ones aren't compatible with the sticky sidebar. Thank goodness for [obscure Stack Overflow answers](https://stackoverflow.com/a/59019025/6074728)

![image](https://user-images.githubusercontent.com/82277/80437749-7a05d880-88d0-11ea-877c-031027a0d5b1.png)
