### PR TITLE
Add underlines to links

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -35,8 +35,9 @@ module.exports = (api) => {
           // Convert ES import/export syntax during tests, since Jest expects
           // CommonJS, not ES import/export syntax
           modules: api.env("test") ? "cjs" : false,
+          // tell babel to transpile to ES5 for older browsers
           targets: {
-            browsers: ["> 1%"],
+            browsers: ["> 1%"], // market share >1% includes IE11, for now
           },
           // replace the "core-js" and "regenerator-runtime/runtime" import
           // statements with specific polyfills

--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -12,10 +12,10 @@ $line-height-lg: 2.2 !default;
 
 $paragraph-margin-bottom: 1.2rem !default;
 
-$h1-font-size:                $font-size-base * 2.0 !default;
-$h2-font-size:                $font-size-base * 2.0 !default;
-$h3-font-size:                $font-size-base * 1.5 !default;
-$h4-font-size:                $font-size-base * 1.25 !default;
+$h1-font-size: $font-size-base * 2 !default;
+$h2-font-size: $font-size-base * 2 !default;
+$h3-font-size: $font-size-base * 1.5 !default;
+$h4-font-size: $font-size-base * 1.25 !default;
 
 @import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;700&display=swap");
 
@@ -35,7 +35,16 @@ h3,
 h4,
 h5,
 h6 {
-    font-weight: bold;
+	font-weight: bold;
+}
+
+a {
+	text-decoration: underline;
+}
+
+.btn,
+.nav-link {
+	text-decoration: none;
 }
 
 // Eliminate whitespace overflow on right half of mobile viewport


### PR DESCRIPTION
This PR adds underlines to links by default, excluding them as appropriate (e.g. when the link is actually part of a button)

I clicked through all the tabs to confirm the links are underlined and the buttons aren't

Also include comment on IE11 from last PR

connects #110 