### PR TITLE
Add some whitespace after the tabbed container

### DIFF
--- a/src/client/components/TabPaneContent3/index.js
+++ b/src/client/components/TabPaneContent3/index.js
@@ -55,8 +55,8 @@ function TabPaneContent3() {
           If you qualify for PUA, your initial weekly benefit amount will be
           $167
         </strong>{" "}
-        for claims starting February 2, 2020. Claims between March 30 to July 31
-        will have an additional, taxable $600. Your total benefits will last for
+        for claims starting February 2, 2020. Claims between March 29 to July
+        25, 2020 will have an additional $600. Your total benefits will last for
         39 weeks (including any regular UI and extended benefits you might
         qualify for).
       </p>

--- a/src/client/components/TabbedContainer/_index.scss
+++ b/src/client/components/TabbedContainer/_index.scss
@@ -1,6 +1,10 @@
 .tabbed-container {
   padding: 2rem 0;
 
+  .TabbedContainer {
+    padding-bottom: 2rem;
+  }
+
   .nav-item {
     border: 1px solid rgba(0, 0, 0, 0.125);
   }


### PR DESCRIPTION
The whitespace seemed pretty good to me. Are there other places we should add some whitespace?

Before:
![guide-mobile-before](https://user-images.githubusercontent.com/175378/80844686-23dcb200-8bbc-11ea-9650-80a6a4208134.png)

Only change:
![Annotation 2020-05-01 145510](https://user-images.githubusercontent.com/175378/80844694-2d661a00-8bbc-11ea-8a1f-25011fa5d771.png)
