### PR TITLE
Provide more space for the footer on mobile.

### DIFF
--- a/src/client/components/Footer/_index.scss
+++ b/src/client/components/Footer/_index.scss
@@ -23,3 +23,15 @@ body {
     font-size: 16px;
   }
 }
+
+@media only screen and (max-width: 900px) {
+  body {
+    margin-bottom: 160px;
+  }
+}
+
+@media only screen and (max-width: 560px) {
+  body {
+    margin-bottom: 240px;
+  }
+}


### PR DESCRIPTION
Content was getting cut off when the footer wrapped.

This is just a temporary fix. Maybe we can refactor the footer later to not be an absolute positioned element.