### PR TITLE
Add routing and fix accessibility issue with keyboard navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12995,6 +12995,14 @@
         }
       }
     },
+    "react-router-bootstrap": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
+      "integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "react-router-dom": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
@@ -13007,6 +13015,15 @@
         "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-router-tabs": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-router-tabs/-/react-router-tabs-1.3.2.tgz",
+      "integrity": "sha512-RZLes3fUTDP4EvDuAOxXt7MRvW2Wpla1ToiNO6E3wEHJs51r4SE7UkVmqou/sBOaUvigweDcaf4f8huNiCGGzA==",
+      "requires": {
+        "@babel/runtime": "^7.4.3",
+        "prop-types": "^15.7.2"
       }
     },
     "react-test-renderer": {

--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -25,3 +25,9 @@ jest.mock(
 jest.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key) => key }),
 }));
+
+jest.mock("react-router-dom", () => ({
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));

--- a/src/client/components/TabPaneContent0/index.js
+++ b/src/client/components/TabPaneContent0/index.js
@@ -2,21 +2,8 @@ import PropTypes from "prop-types";
 import React from "react";
 // import { useTranslation } from "react-i18next";
 
-function TabPaneContent0({ loadTab, tabSlugs, getTabTitle }) {
+function TabPaneContent0({ getTabLink }) {
   // const { t } = useTranslation();
-
-  function ReceiveYourBenefitsLink() {
-    return (
-      <a
-        href={"#" + tabSlugs[4]}
-        onClick={() => {
-          loadTab(4);
-        }}
-      >
-        {getTabTitle(4)}
-      </a>
-    );
-  }
 
   return (
     <div>
@@ -92,8 +79,8 @@ function TabPaneContent0({ loadTab, tabSlugs, getTabTitle }) {
         <li>Your previous UI claim has expired.</li>
       </ul>
       <p>
-        If you're already receiving UI, review <ReceiveYourBenefitsLink /> to
-        learn how your UI claim is affected by COVID-19.
+        If you're already receiving UI, review {getTabLink(4)} to learn how your
+        UI claim is affected by COVID-19.
       </p>
       <h3>Pandemic Unemployment Assistance (PUA)</h3>
       <p>
@@ -179,9 +166,7 @@ function TabPaneContent0({ loadTab, tabSlugs, getTabTitle }) {
 }
 
 TabPaneContent0.propTypes = {
-  loadTab: PropTypes.func,
-  tabSlugs: PropTypes.arrayOf(PropTypes.string),
-  getTabTitle: PropTypes.func,
+  getTabLink: PropTypes.func,
 };
 
 export default TabPaneContent0;

--- a/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
+++ b/src/client/components/TabbedContainer/__snapshots__/index.test.js.snap
@@ -6,7 +6,6 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
 >
   <TabContainer
     activeKey={0}
-    defaultActiveKey="0"
     id="left-tabs"
   >
     <Row
@@ -36,11 +35,13 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={0}
-              href="#benefits"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              to="/guide/benefits"
             >
               tabTitles.0
             </NavLink>
+             
           </NavItem>
           <NavItem
             key="1"
@@ -55,11 +56,13 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={1}
-              href="#before-you-apply"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              to="/guide/before-you-apply"
             >
               tabTitles.1
             </NavLink>
+             
           </NavItem>
           <NavItem
             key="2"
@@ -74,11 +77,13 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={2}
-              href="#how-to-apply"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              to="/guide/how-to-apply"
             >
               tabTitles.2
             </NavLink>
+             
           </NavItem>
           <NavItem
             key="3"
@@ -93,11 +98,13 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={3}
-              href="#after-you-submit"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              to="/guide/after-you-submit"
             >
               tabTitles.3
             </NavLink>
+             
           </NavItem>
           <NavItem
             key="4"
@@ -112,11 +119,13 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={4}
-              href="#receive-benefits"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              to="/guide/receive-benefits"
             >
               tabTitles.4
             </NavLink>
+             
           </NavItem>
           <NavItem
             key="5"
@@ -131,11 +140,13 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
               }
               disabled={false}
               eventKey={5}
-              href="#more-resources"
               onClick={[Function]}
+              onKeyDown={[Function]}
+              to="/guide/more-resources"
             >
               tabTitles.5
             </NavLink>
+             
           </NavItem>
         </Nav>
       </Col>
@@ -143,188 +154,134 @@ exports[`<TabbedContainer /> renders vertical navigation bar 1`] = `
         sm={8}
       >
         <ForwardRef>
-          <TabPane
-            eventKey={0}
-            key="0"
-          >
-            <h2>
-              tabTitles.0
-            </h2>
-            <TabPaneContent0
-              getTabTitle={[Function]}
-              loadTab={[Function]}
-              tabSlugs={
-                Array [
-                  "benefits",
-                  "before-you-apply",
-                  "how-to-apply",
-                  "after-you-submit",
-                  "receive-benefits",
-                  "more-resources",
-                ]
-              }
-            />
-            <Button
-              active={false}
-              disabled={false}
-              href="#before-you-apply"
-              onClick={[Function]}
-              type="button"
-              variant="secondary"
+          <Component>
+            <Component
+              key="0"
+              path="/guide/benefits"
             >
-              buttonNextPrefixtabTitles.1
-            </Button>
-          </TabPane>
-          <TabPane
-            eventKey={1}
-            key="1"
-          >
-            <h2>
-              tabTitles.1
-            </h2>
-            <TabPaneContent1
-              getTabTitle={[Function]}
-              loadTab={[Function]}
-              tabSlugs={
-                Array [
-                  "benefits",
-                  "before-you-apply",
-                  "how-to-apply",
-                  "after-you-submit",
-                  "receive-benefits",
-                  "more-resources",
-                ]
-              }
-            />
-            <Button
-              active={false}
-              disabled={false}
-              href="#how-to-apply"
-              onClick={[Function]}
-              type="button"
-              variant="secondary"
+              <ScrollToTopOnMount />
+              <h2>
+                tabTitles.0
+              </h2>
+              <TabPaneContent0
+                getTabLink={[Function]}
+              />
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                to="/guide/before-you-apply"
+                type="button"
+                variant="secondary"
+              >
+                buttonNextPrefixtabTitles.1
+              </Button>
+            </Component>
+            <Component
+              key="1"
+              path="/guide/before-you-apply"
             >
-              buttonNextPrefixtabTitles.2
-            </Button>
-          </TabPane>
-          <TabPane
-            eventKey={2}
-            key="2"
-          >
-            <h2>
-              tabTitles.2
-            </h2>
-            <TabPaneContent2
-              getTabTitle={[Function]}
-              loadTab={[Function]}
-              tabSlugs={
-                Array [
-                  "benefits",
-                  "before-you-apply",
-                  "how-to-apply",
-                  "after-you-submit",
-                  "receive-benefits",
-                  "more-resources",
-                ]
-              }
-            />
-            <Button
-              active={false}
-              disabled={false}
-              href="#after-you-submit"
-              onClick={[Function]}
-              type="button"
-              variant="secondary"
+              <ScrollToTopOnMount />
+              <h2>
+                tabTitles.1
+              </h2>
+              <TabPaneContent1
+                getTabLink={[Function]}
+              />
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                to="/guide/how-to-apply"
+                type="button"
+                variant="secondary"
+              >
+                buttonNextPrefixtabTitles.2
+              </Button>
+            </Component>
+            <Component
+              key="2"
+              path="/guide/how-to-apply"
             >
-              buttonNextPrefixtabTitles.3
-            </Button>
-          </TabPane>
-          <TabPane
-            eventKey={3}
-            key="3"
-          >
-            <h2>
-              tabTitles.3
-            </h2>
-            <TabPaneContent3
-              getTabTitle={[Function]}
-              loadTab={[Function]}
-              tabSlugs={
-                Array [
-                  "benefits",
-                  "before-you-apply",
-                  "how-to-apply",
-                  "after-you-submit",
-                  "receive-benefits",
-                  "more-resources",
-                ]
-              }
-            />
-            <Button
-              active={false}
-              disabled={false}
-              href="#receive-benefits"
-              onClick={[Function]}
-              type="button"
-              variant="secondary"
+              <ScrollToTopOnMount />
+              <h2>
+                tabTitles.2
+              </h2>
+              <TabPaneContent2
+                getTabLink={[Function]}
+              />
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                to="/guide/after-you-submit"
+                type="button"
+                variant="secondary"
+              >
+                buttonNextPrefixtabTitles.3
+              </Button>
+            </Component>
+            <Component
+              key="3"
+              path="/guide/after-you-submit"
             >
-              buttonNextPrefixtabTitles.4
-            </Button>
-          </TabPane>
-          <TabPane
-            eventKey={4}
-            key="4"
-          >
-            <h2>
-              tabTitles.4
-            </h2>
-            <TabPaneContent4
-              getTabTitle={[Function]}
-              loadTab={[Function]}
-              tabSlugs={
-                Array [
-                  "benefits",
-                  "before-you-apply",
-                  "how-to-apply",
-                  "after-you-submit",
-                  "receive-benefits",
-                  "more-resources",
-                ]
-              }
-            />
-            <Button
-              active={false}
-              disabled={false}
-              href="#more-resources"
-              onClick={[Function]}
-              type="button"
-              variant="secondary"
+              <ScrollToTopOnMount />
+              <h2>
+                tabTitles.3
+              </h2>
+              <TabPaneContent3
+                getTabLink={[Function]}
+              />
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                to="/guide/receive-benefits"
+                type="button"
+                variant="secondary"
+              >
+                buttonNextPrefixtabTitles.4
+              </Button>
+            </Component>
+            <Component
+              key="4"
+              path="/guide/receive-benefits"
             >
-              buttonNextPrefixtabTitles.5
-            </Button>
-          </TabPane>
-          <TabPane
-            eventKey={5}
-            key="5"
-          >
-            <h2>
-              tabTitles.5
-            </h2>
-            <TabPaneContent5
-              getTabTitle={[Function]}
-              loadTab={[Function]}
-              tabSlugs={
-                Array [
-                  "benefits",
-                  "before-you-apply",
-                  "how-to-apply",
-                  "after-you-submit",
-                  "receive-benefits",
-                  "more-resources",
-                ]
-              }
+              <ScrollToTopOnMount />
+              <h2>
+                tabTitles.4
+              </h2>
+              <TabPaneContent4
+                getTabLink={[Function]}
+              />
+              <Button
+                active={false}
+                disabled={false}
+                onClick={[Function]}
+                to="/guide/more-resources"
+                type="button"
+                variant="secondary"
+              >
+                buttonNextPrefixtabTitles.5
+              </Button>
+            </Component>
+            <Component
+              key="5"
+              path="/guide/more-resources"
+            >
+              <ScrollToTopOnMount />
+              <h2>
+                tabTitles.5
+              </h2>
+              <TabPaneContent5
+                getTabLink={[Function]}
+              />
+            </Component>
+            <Component
+              from="/"
+              to="/guide/benefits"
             />
-          </TabPane>
+          </Component>
         </ForwardRef>
       </Col>
     </Row>

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -51,6 +51,8 @@ function TabbedContainer() {
   const handleKeyDown = (event, tabIndex) => {
     let targetTabIndex;
     switch (event.key) {
+      // WAI-ARIA: "If the tabs in a tab list are arranged vertically",
+      // navigate with the up and down keys
       case "ArrowUp":
         targetTabIndex = tabIndex - 1;
         break;
@@ -64,6 +66,10 @@ function TabbedContainer() {
 
     event.preventDefault();
     setActiveTabIndex(targetTabIndex);
+
+    // WAI-ARIA: "It is recommended that tabs activate automatically when
+    // they receive focus as long as their associated tab panels are displayed
+    // without noticeable latency."
     history.push(prefix + tabSlugs[targetTabIndex]);
   };
 

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -45,7 +45,6 @@ function TabbedContainer() {
   // navigation outside of the sidebar tabs (internal links, the Next buttons)
   const initialTabIndex = 0;
   const [activeTabIndex, setActiveTabIndex] = useState(initialTabIndex);
-  const activeNavItem = useRef(null);
 
   // Follows accessibility specs: https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
   const handleKeyDown = (event, tabIndex) => {
@@ -138,7 +137,7 @@ function TabbedContainer() {
             <Nav variant="pills" className="flex-column sidebar-sticky">
               {tabSlugs.map((value, index) => {
                 return (
-                  <Nav.Item key={index} ref={activeNavItem}>
+                  <Nav.Item key={index}>
                     <Nav.Link
                       as={Link}
                       eventKey={index}

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -39,15 +39,15 @@ function TabbedContainer() {
     TabPaneContent5,
   ];
 
-  // We must manually manage the active tab state because we need to change
-  // the tab state when the user clicks internal links and the Next buttons
+  // The default "uncontrolled" React Bootstrap tab container automatically
+  // manages active tab state and keypresses, but we must do that manually
+  // because we need to update the active tab when the user clicks on
+  // navigation outside of the sidebar tabs (internal links, the Next buttons)
   const initialTabIndex = 0;
   const [activeTabIndex, setActiveTabIndex] = useState(initialTabIndex);
   const activeNavItem = useRef(null);
 
-  // The default "uncontrolled" React Bootstrap tab container manages
-  // keypresses, but we need to manage them manually here. We follow
-  // accessibility specs: https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
+  // Follows accessibility specs: https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
   const handleKeyDown = (event, tabIndex) => {
     let targetTabIndex;
     switch (event.key) {

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -1,3 +1,4 @@
+import { Link, Redirect, Route, Switch, useHistory } from "react-router-dom";
 import React, { useEffect, useRef, useState } from "react";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
@@ -11,7 +12,6 @@ import TabPaneContent2 from "../TabPaneContent2";
 import TabPaneContent3 from "../TabPaneContent3";
 import TabPaneContent4 from "../TabPaneContent4";
 import TabPaneContent5 from "../TabPaneContent5";
-import logEvent from "../../utils.js";
 import { useTranslation } from "react-i18next";
 
 function TabbedContainer() {
@@ -39,32 +39,32 @@ function TabbedContainer() {
     TabPaneContent5,
   ];
 
+  // We must manage the active tab state (a "controlled" component) because we
+  // need to change it when the user clicks internal links and the Next buttons
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const activeNavItem = useRef(null);
   const tabbedContainer = useRef(null);
-  const [activeTab, setActiveTab] = useState(0);
+  const prefix = "/guide/";
+  const initialTabIndex = 0;
   const initialPageLoad = useRef(true);
+  const history = useHistory();
 
-  // Scroll to the top of the sidebar when activeTab changes
-  // and log tab change to Google Analytics
-  useEffect(() => {
-    // Don't scroll down to the top of the sidebar on initial page load
-    if (initialPageLoad.current) {
-      initialPageLoad.current = false;
-      return;
-    }
+  // Scroll to the top of the sidebar when a tab content pane loads
+  function ScrollToTopOnMount() {
+    useEffect(() => {
+      // Don't scroll down to the top of the sidebar on initial page load
+      if (initialPageLoad.current) {
+        initialPageLoad.current = false;
+        return;
+      }
 
-    const sidebarOffset = tabbedContainer.current.offsetTop;
-
-    // we use smoothscroll-polyfill for Edge/IE
-    window.scroll({
-      top: sidebarOffset,
-      left: 0,
-      behavior: "smooth",
-    });
-  }, [activeTab]);
-
-  function loadTab(tabIndex) {
-    setActiveTab(tabIndex);
-    logEvent(getTabHashFragment(activeTab));
+      // we use smoothscroll-polyfill for Edge/IE
+      window.scroll({
+        top: tabbedContainer.current.offsetTop,
+        left: 0,
+        behavior: "smooth",
+      });
+    }, []);
 
     return null;
   }
@@ -73,42 +73,75 @@ function TabbedContainer() {
     return t("tabTitles." + tabIndex);
   }
 
-  function getTabHashFragment(tabIndex) {
-    return `#${tabSlugs[tabIndex]}`;
+  function getTabLink(tabIndex) {
+    return (
+      <Link
+        to={prefix + tabSlugs[tabIndex]}
+        onClick={() => setActiveTabIndex(tabIndex)}
+      >
+        {getTabTitle(tabIndex)}
+      </Link>
+    );
   }
 
-  const renderNextButton = (tabIndex) => {
-    // Don't display the next button on the final tab
-    if (tabIndex < tabSlugs.length - 1) {
-      const nextTabIndex = tabIndex + 1;
-      return (
-        <Button
-          variant="secondary"
-          href={getTabHashFragment(nextTabIndex)}
-          onClick={() => loadTab(nextTabIndex)}
-        >
-          {t("buttonNextPrefix") + getTabTitle(nextTabIndex)}
-        </Button>
-      );
+  const handleKeyDown = (event, tabIndex) => {
+    let targetTabIndex;
+    switch (event.key) {
+      case "ArrowUp":
+        targetTabIndex = tabIndex - 1;
+        break;
+      case "ArrowDown":
+        targetTabIndex = tabIndex + 1;
+        break;
+      default:
+        return;
     }
+    if (targetTabIndex < 0 || targetTabIndex > tabSlugs.length - 1) return;
+
+    event.preventDefault();
+    setActiveTabIndex(targetTabIndex);
+    history.push(prefix + tabSlugs[targetTabIndex]);
+  };
+
+  const renderNextButton = (tabIndex) => {
+    // Don't render a next button on the final tab
+    if (tabIndex >= tabSlugs.length - 1) return;
+
+    const nextTabIndex = tabIndex + 1;
+    return (
+      <Button
+        variant="secondary"
+        as={Link}
+        to={prefix + tabSlugs[nextTabIndex]}
+        onClick={() => setActiveTabIndex(nextTabIndex)}
+      >
+        {t("buttonNextPrefix") + getTabTitle(nextTabIndex)}
+      </Button>
+    );
   };
 
   return (
     <Container ref={tabbedContainer}>
-      <Tab.Container id="left-tabs" defaultActiveKey="0" activeKey={activeTab}>
+      <Tab.Container
+        id="left-tabs"
+        defaultActiveKey={initialTabIndex}
+        activeKey={activeTabIndex}
+      >
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
             <Nav variant="pills" className="flex-column sidebar-sticky">
               {tabSlugs.map((value, index) => {
                 return (
-                  <Nav.Item key={index}>
+                  <Nav.Item key={index} ref={activeNavItem}>
                     <Nav.Link
+                      as={Link}
                       eventKey={index}
-                      href={getTabHashFragment(index)}
-                      onClick={() => loadTab(index)}
+                      to={prefix + value}
+                      onClick={() => setActiveTabIndex(index)}
+                      onKeyDown={(event) => handleKeyDown(event, index)}
                     >
                       {getTabTitle(index)}
-                    </Nav.Link>
+                    </Nav.Link>{" "}
                   </Nav.Item>
                 );
               })}
@@ -116,20 +149,20 @@ function TabbedContainer() {
           </Col>
           <Col sm={8}>
             <Tab.Content>
-              {tabSlugs.map((value, index) => {
-                const TabPaneContentTagName = tabPaneContent[index];
-                return (
-                  <Tab.Pane eventKey={index} key={index}>
-                    <h2>{getTabTitle(index)}</h2>
-                    <TabPaneContentTagName
-                      getTabTitle={getTabTitle}
-                      loadTab={loadTab}
-                      tabSlugs={tabSlugs}
-                    />
-                    {renderNextButton(index)}
-                  </Tab.Pane>
-                );
-              })}
+              <Switch>
+                {tabSlugs.map((value, index) => {
+                  const TabPaneContentTagName = tabPaneContent[index];
+                  return (
+                    <Route path={prefix + value} key={index}>
+                      <ScrollToTopOnMount />
+                      <h2>{getTabTitle(index)}</h2>
+                      <TabPaneContentTagName getTabLink={getTabLink} />
+                      {renderNextButton(index)}
+                    </Route>
+                  );
+                })}
+                <Redirect from="/" to={prefix + tabSlugs[initialTabIndex]} />
+              </Switch>
             </Tab.Content>
           </Col>
         </Row>

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -39,13 +39,36 @@ function TabbedContainer() {
     TabPaneContent5,
   ];
 
-  // We must manage the active tab state (a "controlled" component) because we
-  // need to change it when the user clicks internal links and the Next buttons
-  const [activeTabIndex, setActiveTabIndex] = useState(0);
+  // We must manually manage the active tab state because we need to change
+  // the tab state when the user clicks internal links and the Next buttons
+  const initialTabIndex = 0;
+  const [activeTabIndex, setActiveTabIndex] = useState(initialTabIndex);
   const activeNavItem = useRef(null);
+
+  // The default "uncontrolled" React Bootstrap tab container manages
+  // keypresses, but we need to manage them manually here. We follow
+  // accessibility specs: https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel
+  const handleKeyDown = (event, tabIndex) => {
+    let targetTabIndex;
+    switch (event.key) {
+      case "ArrowUp":
+        targetTabIndex = tabIndex - 1;
+        break;
+      case "ArrowDown":
+        targetTabIndex = tabIndex + 1;
+        break;
+      default:
+        return;
+    }
+    if (targetTabIndex < 0 || targetTabIndex > tabSlugs.length - 1) return;
+
+    event.preventDefault();
+    setActiveTabIndex(targetTabIndex);
+    history.push(prefix + tabSlugs[targetTabIndex]);
+  };
+
   const tabbedContainer = useRef(null);
   const prefix = "/guide/";
-  const initialTabIndex = 0;
   const initialPageLoad = useRef(true);
   const history = useHistory();
 
@@ -84,25 +107,6 @@ function TabbedContainer() {
     );
   }
 
-  const handleKeyDown = (event, tabIndex) => {
-    let targetTabIndex;
-    switch (event.key) {
-      case "ArrowUp":
-        targetTabIndex = tabIndex - 1;
-        break;
-      case "ArrowDown":
-        targetTabIndex = tabIndex + 1;
-        break;
-      default:
-        return;
-    }
-    if (targetTabIndex < 0 || targetTabIndex > tabSlugs.length - 1) return;
-
-    event.preventDefault();
-    setActiveTabIndex(targetTabIndex);
-    history.push(prefix + tabSlugs[targetTabIndex]);
-  };
-
   const renderNextButton = (tabIndex) => {
     // Don't render a next button on the final tab
     if (tabIndex >= tabSlugs.length - 1) return;
@@ -122,11 +126,7 @@ function TabbedContainer() {
 
   return (
     <Container ref={tabbedContainer}>
-      <Tab.Container
-        id="left-tabs"
-        defaultActiveKey={initialTabIndex}
-        activeKey={activeTabIndex}
-      >
+      <Tab.Container id="left-tabs" activeKey={activeTabIndex}>
         <Row className="tabbed-container">
           <Col sm={4} className="TabbedContainer">
             <Nav variant="pills" className="flex-column sidebar-sticky">

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,6 +3,7 @@ import "regenerator-runtime/runtime";
 import "whatwg-fetch";
 import "./i18n";
 import App from "./App";
+import { BrowserRouter } from "react-router-dom";
 import React from "react";
 import { render } from "react-dom";
 import smoothscroll from "smoothscroll-polyfill";
@@ -10,4 +11,9 @@ import smoothscroll from "smoothscroll-polyfill";
 // Enables scrolling (not just smooth scrolling) on Edge and IE
 smoothscroll.polyfill();
 
-render(<App />, document.getElementById("root"));
+render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
+  document.getElementById("root")
+);


### PR DESCRIPTION
This PR:
* replaces the hash fragment "routing" with actual routing (resolves #102)
* once tabbed to the active sidebar item, enables using the up / down key to navigate the sidebar (which the default "uncontrolled" React Bootstrap tabs component does, but it's not compatible with the Next buttons and internal links-- those require us to manage tab state), and automatically loads the corresponding tab content pane (optional but recommended in WAI-ARIA) (resolves #115)

Can't figure out why I'm getting these warnings when updating snapshots, any ideas? 
![image](https://user-images.githubusercontent.com/82277/80939085-60b9cc00-8da9-11ea-8567-91958eeef081.png)