### PR TITLE
Position footer using flexbox

### DIFF
--- a/src/client/App.scss
+++ b/src/client/App.scss
@@ -58,3 +58,21 @@ a {
 main {
 	display: block;
 }
+
+// This keeps the footer at the bottom of the page, even if the main
+// content is short. This doesn't work in IE, but degrades reasonably
+// well (the content doesn't grow if needed).
+#overflow-wrapper {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+}
+header {
+	flex: 0 0 auto;
+}
+main {
+	flex: 1 0 auto;
+}
+footer {
+	flex: 0 0 auto;
+}

--- a/src/client/components/Footer/_index.scss
+++ b/src/client/components/Footer/_index.scss
@@ -1,18 +1,4 @@
-// This code is to ensure that our footer stays at the bottom of the page.
-
-html {
-  position: relative;
-  min-height: 100%;
-}
-body {
-  margin-bottom: 120px;
-}
-
 .footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-
   .navbar-custom .navbar-nav .nav-link {
     color: #ffffff;
     font-size: 16px;
@@ -21,17 +7,5 @@ body {
   .secondary-footer {
     line-height: 60px;
     font-size: 16px;
-  }
-}
-
-@media only screen and (max-width: 900px) {
-  body {
-    margin-bottom: 160px;
-  }
-}
-
-@media only screen and (max-width: 560px) {
-  body {
-    margin-bottom: 240px;
   }
 }


### PR DESCRIPTION
Rather than using position: absolute, use
flexbox to grow the content if needed to make the
footer stick to the bottom of the page. This avoids
having to know the height of the footer in advance.

Fixes #131