### PR TITLE
Enable Google Analytics tracking of URL slugs

### DIFF
--- a/setupTestFramework.js
+++ b/setupTestFramework.js
@@ -29,5 +29,6 @@ jest.mock("react-i18next", () => ({
 jest.mock("react-router-dom", () => ({
   useHistory: () => ({
     push: jest.fn(),
+    listen: jest.fn(),
   }),
 }));

--- a/src/client/components/BPOButton/index.js
+++ b/src/client/components/BPOButton/index.js
@@ -1,6 +1,6 @@
 import Button from "react-bootstrap/Button";
 import React from "react";
-import logEvent from "../../utils.js";
+import { logEvent } from "../../utils.js";
 
 function BPOButton() {
   return (

--- a/src/client/components/TabbedContainer/index.js
+++ b/src/client/components/TabbedContainer/index.js
@@ -12,6 +12,7 @@ import TabPaneContent2 from "../TabPaneContent2";
 import TabPaneContent3 from "../TabPaneContent3";
 import TabPaneContent4 from "../TabPaneContent4";
 import TabPaneContent5 from "../TabPaneContent5";
+import { logPage } from "../../utils.js";
 import { useTranslation } from "react-i18next";
 
 function TabbedContainer() {
@@ -76,6 +77,7 @@ function TabbedContainer() {
   const prefix = "/guide/";
   const initialPageLoad = useRef(true);
   const history = useHistory();
+  history.listen((location) => logPage(location.pathname));
 
   // Scroll to the top of the sidebar when a tab content pane loads
   function ScrollToTopOnMount() {

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -1,7 +1,22 @@
-// log to Google Analytics
-export default function LogEvent(label) {
+const cagovPropertyId = "UA-3419582-2";
+const eddPropertyId = "UA-3419582-31";
+
+// log event to Google Analytics
+export function logEvent(label) {
   window.gtag("event", "Navigate", {
     event_category: "Unemployment",
     event_label: label,
+  });
+}
+
+// log page to Google Analytics (for client-side routing)
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export function logPage(path) {
+  window.gtag("config", cagovPropertyId, {
+    page_path: path,
+  });
+
+  window.gtag("config", eddPropertyId, {
+    page_path: path,
   });
 }


### PR DESCRIPTION
#128 added routing but removed event tracking in GA, this PR adds GA tracking back in, now using the standard URL slugs instead of Events.

Tested and working (see "how-to-apply"):
![image](https://user-images.githubusercontent.com/82277/81001577-f25f2300-8e15-11ea-9357-1654006e4e03.png)
